### PR TITLE
fix(list): fix mobile padding #552

### DIFF
--- a/src/tedi/components/content/list/list.module.scss
+++ b/src/tedi/components/content/list/list.module.scss
@@ -23,12 +23,12 @@ $bullet-colors: (
 }
 
 .tedi-list--unordered {
-  padding-left: var(--list-padding-left-level-1);
+  padding-left: calc(var(--list-inner-spacing-x) + var(--list-icon-size));
   list-style: none;
 
   .tedi-list__item {
     position: relative;
-    padding-left: var(--list-padding-left-level-1);
+    padding-left: calc(var(--list-inner-spacing-x) + var(--list-icon-size));
 
     &::before {
       position: absolute;
@@ -67,7 +67,7 @@ $bullet-colors: (
 }
 
 .tedi-list--ordered {
-  padding-left: var(--list-padding-left-level-1);
+  padding-left: calc(var(--list-inner-spacing-x) + var(--list-icon-size));
   list-style: none;
   counter-reset: item;
 


### PR DESCRIPTION
done like in Angular solely for the reason that `var(--list-padding-left-level-1);` has smaller padding in mobile devices (comes from Figma)