### PR TITLE
feat(tooltip): Add shift altBoundary: true to tooltip-provider.tsx https://github.com/TEDI-Design-System/react/issues/566

### DIFF
--- a/src/community/components/tooltip/tooltip-provider.tsx
+++ b/src/community/components/tooltip/tooltip-provider.tsx
@@ -10,7 +10,6 @@ import {
   ReferenceType,
   safePolygon,
   shift,
-  ShiftOptions,
   Strategy,
   useClick,
   useDismiss,
@@ -82,7 +81,6 @@ export interface TooltipProviderProps {
    * Optional Floating UI shift configuration.
    * Use this to keep tooltip content inside a specific visible area (for example by setting `boundary`).
    */
-  shift?: ShiftOptions;
 }
 
 export interface ITooltipContext {
@@ -141,7 +139,6 @@ export const TooltipProvider = (props: TooltipProviderProps): JSX.Element => {
     onToggle,
     role = 'tooltip',
     offset: offsetOptions = DEFAULT_TOOLTIP_OFFSET,
-    shift: shiftOptions,
   } = props;
   const {
     order = ['reference', 'content'],
@@ -171,7 +168,10 @@ export const TooltipProvider = (props: TooltipProviderProps): JSX.Element => {
     middleware: [
       offset(offsetOptions),
       flip(),
-      shift(shiftOptions),
+      shift({
+        altBoundary: true,
+        padding: 8,
+      }),
       arrow({
         element: arrowRef,
         padding: 4,

--- a/src/community/components/tooltip/tooltip-provider.tsx
+++ b/src/community/components/tooltip/tooltip-provider.tsx
@@ -10,6 +10,7 @@ import {
   ReferenceType,
   safePolygon,
   shift,
+  ShiftOptions,
   Strategy,
   useClick,
   useDismiss,
@@ -77,6 +78,11 @@ export interface TooltipProviderProps {
    * @default GAP + ARROW_HEIGHT (3px + 7px)
    */
   offset?: OffsetOptions;
+  /**
+   * Optional Floating UI shift configuration.
+   * Use this to keep tooltip content inside a specific visible area (for example by setting `boundary`).
+   */
+  shift?: ShiftOptions;
 }
 
 export interface ITooltipContext {
@@ -135,6 +141,7 @@ export const TooltipProvider = (props: TooltipProviderProps): JSX.Element => {
     onToggle,
     role = 'tooltip',
     offset: offsetOptions = DEFAULT_TOOLTIP_OFFSET,
+    shift: shiftOptions,
   } = props;
   const {
     order = ['reference', 'content'],
@@ -164,7 +171,7 @@ export const TooltipProvider = (props: TooltipProviderProps): JSX.Element => {
     middleware: [
       offset(offsetOptions),
       flip(),
-      shift({ padding: 8 }),
+      shift(shiftOptions),
       arrow({
         element: arrowRef,
         padding: 4,
@@ -184,6 +191,7 @@ export const TooltipProvider = (props: TooltipProviderProps): JSX.Element => {
     }),
     useRole(context, { role }),
     useDismiss(context, {
+      ancestorScroll: true,
       outsidePressEvent: openWith === 'click' ? 'mousedown' : 'pointerdown', // https://floating-ui.com/docs/dialog#interaction-hooks
     }),
   ]);

--- a/src/community/components/tooltip/tooltip-provider.tsx
+++ b/src/community/components/tooltip/tooltip-provider.tsx
@@ -77,10 +77,6 @@ export interface TooltipProviderProps {
    * @default GAP + ARROW_HEIGHT (3px + 7px)
    */
   offset?: OffsetOptions;
-  /**
-   * Optional Floating UI shift configuration.
-   * Use this to keep tooltip content inside a specific visible area (for example by setting `boundary`).
-   */
 }
 
 export interface ITooltipContext {

--- a/src/community/components/tooltip/tooltip.stories.tsx
+++ b/src/community/components/tooltip/tooltip.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryFn, StoryObj } from '@storybook/react';
+import { useState } from 'react';
 
 import { Heading } from '../../../tedi/components/base//typography/heading/heading';
 import { Icon } from '../../../tedi/components/base/icon/icon';
@@ -249,6 +250,35 @@ export const TooltipPosition: StoryFn = () => {
           </TooltipTrigger>
           <Tooltip>{tooltiptext}</Tooltip>
         </TooltipProvider>
+      </Col>
+    </Row>
+  );
+};
+
+export const ScrollableRowInCard: StoryFn = () => {
+  const [tooltipBoundary, setTooltipBoundary] = useState<HTMLElement | null>();
+  const shiftOptions: TooltipProviderProps['shift'] = tooltipBoundary ? { boundary: tooltipBoundary } : undefined;
+
+  return (
+    <Row justifyContent="center">
+      <Col width="auto" style={{ width: '100%' }}>
+        <div ref={setTooltipBoundary} style={{ width: '100%', overflowX: 'scroll' }}>
+          <div style={{ minWidth: '100rem' }}>
+            <TooltipProvider shift={shiftOptions}>
+              <TooltipTrigger>
+                <span
+                  style={{
+                    display: 'block',
+                    width: 'fit-content',
+                  }}
+                >
+                  Lorem ipsum dolor sit amet
+                </span>
+              </TooltipTrigger>
+              <Tooltip>Lorem ipsum dolor sit amet</Tooltip>
+            </TooltipProvider>
+          </div>
+        </div>
       </Col>
     </Row>
   );

--- a/src/community/components/tooltip/tooltip.stories.tsx
+++ b/src/community/components/tooltip/tooltip.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, StoryFn, StoryObj } from '@storybook/react';
-import { useState } from 'react';
 
 import { Heading } from '../../../tedi/components/base//typography/heading/heading';
 import { Icon } from '../../../tedi/components/base/icon/icon';
@@ -256,15 +255,12 @@ export const TooltipPosition: StoryFn = () => {
 };
 
 export const ScrollableRowInCard: StoryFn = () => {
-  const [tooltipBoundary, setTooltipBoundary] = useState<HTMLElement | null>();
-  const shiftOptions: TooltipProviderProps['shift'] = tooltipBoundary ? { boundary: tooltipBoundary } : undefined;
-
   return (
     <Row justifyContent="center">
       <Col width="auto" style={{ width: '100%' }}>
-        <div ref={setTooltipBoundary} style={{ width: '100%', overflowX: 'scroll' }}>
+        <div style={{ width: '100%', overflowX: 'scroll' }}>
           <div style={{ minWidth: '100rem' }}>
-            <TooltipProvider shift={shiftOptions}>
+            <TooltipProvider>
               <TooltipTrigger>
                 <span
                   style={{


### PR DESCRIPTION
This solves the issue where the tooltip can open outside of the component if scrolling is possible.
Added ancestorScroll: true to TooltipProvider to close the tooltip when scrolling.

Without shift altBoundary:
<img width="720" height="228" alt="image" src="https://github.com/user-attachments/assets/41a01fce-2b83-4cc4-b2d0-be130d5035e2" />

With shift altBoundary:
<img width="498" height="249" alt="image" src="https://github.com/user-attachments/assets/b9e1460b-0de3-4753-9b4a-21c59fc65ebc" />
