### PR TITLE
chore: improve secondary color Spinner visibility in Storybook #576

### DIFF
--- a/src/tedi/components/loaders/spinner/spinner.stories.tsx
+++ b/src/tedi/components/loaders/spinner/spinner.stories.tsx
@@ -1,4 +1,5 @@
-import { Meta, StoryFn, StoryObj } from '@storybook/react';
+import { Meta, StoryContext, StoryFn, StoryObj } from '@storybook/react';
+import { useEffect } from 'react';
 
 import { Col, Row } from '../../layout/grid';
 import { Spinner, SpinnerProps } from './spinner';
@@ -7,6 +8,24 @@ import { Spinner, SpinnerProps } from './spinner';
  * <a href="https://www.figma.com/file/jWiRIXhHRxwVdMSimKX2FF/TEDI-Design-System-(draft)?type=design&node-id=2768-42334&mode=dev" target="_BLANK">Figma ↗</a><br/>
  * <a href="https://www.tedi.ee/1ee8444b7/p/13d6ac-spinner" target="_BLANK">Zeroheight ↗</a>
  */
+
+const withConditionalCanvasBackground = (Story: StoryFn, context: StoryContext) => {
+  const { color } = context.args;
+
+  useEffect(() => {
+    const bg = color === 'secondary' ? 'var(--color-bg-inverted)' : 'var(--color-bg-default)';
+
+    document.querySelectorAll('.sb-show-main, .docs-story > div, .sbdocs-preview').forEach((el) => {
+      const element = el as HTMLElement;
+      if (element) {
+        element.style.backgroundColor = bg;
+        element.style.transition = 'background-color 0.2s ease';
+      }
+    });
+  }, [color]);
+
+  return <Story />;
+};
 
 const meta: Meta<typeof Spinner> = {
   component: Spinner,
@@ -88,6 +107,7 @@ export const Default: Story = {
     color: 'primary',
     label: 'Loading...',
   },
+  decorators: [withConditionalCanvasBackground],
 };
 
 export const Size: StoryObj<TemplateMultipleProps> = {

--- a/src/tedi/components/loaders/spinner/spinner.stories.tsx
+++ b/src/tedi/components/loaders/spinner/spinner.stories.tsx
@@ -19,6 +19,7 @@ const withConditionalCanvasBackground = (Story: StoryFn, context: StoryContext) 
     elements.forEach((el) => {
       const element = el as HTMLElement;
       element.style.backgroundColor = bg;
+      element.style.color = 'var(--color-text-inverted)';
       element.style.transition = 'background-color 0.2s ease';
     });
 

--- a/src/tedi/components/loaders/spinner/spinner.stories.tsx
+++ b/src/tedi/components/loaders/spinner/spinner.stories.tsx
@@ -14,14 +14,20 @@ const withConditionalCanvasBackground = (Story: StoryFn, context: StoryContext) 
 
   useEffect(() => {
     const bg = color === 'secondary' ? 'var(--color-bg-inverted)' : 'var(--color-bg-default)';
+    const elements = document.querySelectorAll('.sb-show-main, .docs-story > div, .sbdocs-preview');
 
-    document.querySelectorAll('.sb-show-main, .docs-story > div, .sbdocs-preview').forEach((el) => {
+    elements.forEach((el) => {
       const element = el as HTMLElement;
-      if (element) {
-        element.style.backgroundColor = bg;
-        element.style.transition = 'background-color 0.2s ease';
-      }
+      element.style.backgroundColor = bg;
+      element.style.transition = 'background-color 0.2s ease';
     });
+
+    return () => {
+      elements.forEach((el) => {
+        const element = el as HTMLElement;
+        element.style.backgroundColor = '';
+      });
+    };
   }, [color]);
 
   return <Story />;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Spinner stories now include a decorator that adapts the preview canvas background based on the story control for color, with a smooth transition.
  * The decorator cleans up styles when the story changes or unmounts.
  * The default story uses the new adaptive preview; size and color variant stories remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->