### PR TITLE
fix(select): select placeholder no longer blocks context menu interactions #584

### DIFF
--- a/src/community/components/form/select/select.module.scss
+++ b/src/community/components/form/select/select.module.scss
@@ -133,6 +133,7 @@ div.select__multi-value-item {
 
   .select__value-container .select__placeholder {
     color: var(--color-text-subtle);
+    pointer-events: none;
   }
 
   .select__value-container--is-multi .select__placeholder {

--- a/src/tedi/components/form/select/select.module.scss
+++ b/src/tedi/components/form/select/select.module.scss
@@ -196,6 +196,7 @@ div.tedi-select__multi-value-item {
 
     .tedi-select__placeholder {
       color: var(--form-input-text-placeholder);
+      pointer-events: none;
     }
   }
 }


### PR DESCRIPTION
fix(select): select placeholder no longer blocks context menu interactions #584

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fixed placeholder interaction handling in select form components to prevent unintended pointer event interception, ensuring proper click behavior across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->