### PR TITLE
feat(textarea): add autoGrow, height and maxHeight props #588

### DIFF
--- a/src/tedi/components/form/textarea/textarea.module.scss
+++ b/src/tedi/components/form/textarea/textarea.module.scss
@@ -1,14 +1,19 @@
 .tedi-textarea {
   &__input {
+    box-sizing: border-box;
     display: block;
-    height: auto;
-    min-height: 7.5rem;
-    font-family: inherit;
-    font-weight: 400;
+    width: 100%;
+    line-height: 1.5;
     resize: vertical;
+
+    &--auto-grow {
+      overflow-y: auto;
+      resize: none;
+    }
   }
 
   &__character-count {
     flex-grow: 1;
+    text-align: right;
   }
 }

--- a/src/tedi/components/form/textarea/textarea.spec.tsx
+++ b/src/tedi/components/form/textarea/textarea.spec.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { useBreakpointProps } from '../../../helpers';
+import { UnknownType } from '../../../types/commonTypes';
 import TextArea, { TextAreaProps } from './textarea';
 
 import '@testing-library/jest-dom';
@@ -93,6 +94,10 @@ describe('TextArea component', () => {
       paddingBottom: '8px',
     }));
 
+    const originalScrollHeightDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      'scrollHeight'
+    );
     Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {
       configurable: true,
       get() {
@@ -101,9 +106,7 @@ describe('TextArea component', () => {
     });
 
     render(<TextArea {...defaultProps} autoGrow minRows={3} maxRows={10} />);
-
     const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
-
     expect(textarea).toHaveAttribute('rows', '3');
 
     await act(async () => {
@@ -115,8 +118,13 @@ describe('TextArea component', () => {
     });
 
     expect(parseFloat(textarea.style.height || '0')).toBeGreaterThan(120);
-
     window.getComputedStyle = originalGetComputedStyle;
+
+    if (originalScrollHeightDescriptor) {
+      Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', originalScrollHeightDescriptor);
+    } else {
+      delete (HTMLTextAreaElement.prototype as UnknownType).scrollHeight;
+    }
   });
 
   it('respects maxRows and enables scroll when exceeded with autoGrow', async () => {

--- a/src/tedi/components/form/textarea/textarea.spec.tsx
+++ b/src/tedi/components/form/textarea/textarea.spec.tsx
@@ -40,14 +40,147 @@ describe('TextArea component', () => {
     expect(textarea).toHaveClass('tedi-textarea__input');
   });
 
-  it('displays error when char count is over character limit', () => {
+  it('displays error when char count exceeds characterLimit', () => {
     const charLimit = 10;
     const newText = 'This text is too long';
     render(<TextArea {...defaultProps} characterLimit={charLimit} />);
     const textarea = screen.getByPlaceholderText(/enter text/i);
     fireEvent.change(textarea, { target: { value: newText } });
+
     const error = screen.getByText(`${newText.length}/${charLimit}`);
     expect(error).toHaveClass('tedi-feedback-text--error');
+  });
+
+  it('displays character counter as hint when under limit', () => {
+    render(<TextArea {...defaultProps} characterLimit={15} />);
+    const textarea = screen.getByPlaceholderText(/enter text/i);
+    fireEvent.change(textarea, { target: { value: 'Short text' } });
+
+    const counter = screen.getByText(/10\/15/i);
+    expect(counter).toHaveClass('tedi-feedback-text--hint');
+  });
+
+  it('displays a character counter when characterLimit is set', () => {
+    render(<TextArea {...defaultProps} characterLimit={15} />);
+    const textarea = screen.getByPlaceholderText(/enter text/i);
+    fireEvent.change(textarea, { target: { value: 'Some text' } });
+    const counter = screen.getByText(/9\/15/i);
+    expect(counter).toBeInTheDocument();
+  });
+
+  it('does not display a character counter when characterLimit is not set', () => {
+    render(<TextArea {...defaultProps} />);
+    const textarea = screen.getByPlaceholderText(/enter text/i);
+    fireEvent.change(textarea, { target: { value: 'Some text' } });
+    const counter = screen.queryByText(/\d+\/\d+/i);
+    expect(counter).not.toBeInTheDocument();
+  });
+
+  it('applies minRows when autoGrow is enabled', () => {
+    render(<TextArea {...defaultProps} autoGrow minRows={5} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(textarea).toHaveAttribute('rows', '5');
+  });
+
+  it('grows height when typing with autoGrow=true', async () => {
+    const user = userEvent.setup();
+
+    const originalGetComputedStyle = window.getComputedStyle;
+    window.getComputedStyle = jest.fn().mockImplementation((el) => ({
+      ...originalGetComputedStyle(el),
+      lineHeight: '20px',
+      paddingTop: '8px',
+      paddingBottom: '8px',
+    }));
+
+    Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        return 100 + (this.value.split('\n').length - 1) * 40;
+      },
+    });
+
+    render(<TextArea {...defaultProps} autoGrow minRows={3} maxRows={10} />);
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+
+    expect(textarea).toHaveAttribute('rows', '3');
+
+    await act(async () => {
+      await user.type(textarea, 'Line 1\nLine 2\nLine 3\nLine 4\nLine 5');
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(parseFloat(textarea.style.height || '0')).toBeGreaterThan(120);
+
+    window.getComputedStyle = originalGetComputedStyle;
+  });
+
+  it('respects maxRows and enables scroll when exceeded with autoGrow', async () => {
+    const user = userEvent.setup();
+
+    const originalGetComputedStyle = window.getComputedStyle;
+    window.getComputedStyle = jest.fn().mockImplementation((el) => ({
+      ...originalGetComputedStyle(el),
+      lineHeight: '20px',
+      paddingTop: '8px',
+      paddingBottom: '8px',
+    }));
+
+    Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        return 400;
+      },
+    });
+
+    render(<TextArea {...defaultProps} autoGrow minRows={3} maxRows={5} />);
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+
+    await act(async () => {
+      await user.type(textarea, 'Line1\nLine2\nLine3\nLine4\nLine5\nLine6\nLine7\nLine8');
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(textarea.style.overflowY).toBe('auto');
+    const height = parseFloat(textarea.style.height || '0');
+    expect(height).toBeGreaterThan(100);
+    expect(height).toBeLessThan(200);
+
+    window.getComputedStyle = originalGetComputedStyle;
+  });
+
+  it('applies maxHeight when autoGrow=true', () => {
+    render(<TextArea {...defaultProps} autoGrow maxHeight="200px" />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(textarea.style.maxHeight).toBe('200px');
+  });
+
+  // === Fixed height (non-autoGrow) Tests ===
+  it('applies fixed height when autoGrow=false (default)', () => {
+    render(<TextArea {...defaultProps} height="200px" />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(textarea.style.height).toBe('200px');
+  });
+
+  it('uses default height 7.5rem when not specified and autoGrow=false', () => {
+    render(<TextArea {...defaultProps} />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(textarea.style.height).toBe('7.5rem');
+  });
+
+  it('applies maxHeight when autoGrow=false', () => {
+    render(<TextArea {...defaultProps} height="150px" maxHeight="300px" />);
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(textarea.style.height).toBe('150px');
+    expect(textarea.style.maxHeight).toBe('300px');
   });
 
   it('disables the textarea when disabled prop is true', () => {
@@ -66,22 +199,6 @@ describe('TextArea component', () => {
     render(<TextArea {...defaultProps} invalid helper={{ type: 'error', text: 'Error message' }} />);
     const error = screen.getByText(/error message/i);
     expect(error).toHaveClass('tedi-feedback-text--error');
-  });
-
-  it('displays a character counter when characterLimit is set', () => {
-    render(<TextArea {...defaultProps} characterLimit={15} />);
-    const textarea = screen.getByPlaceholderText(/enter text/i);
-    fireEvent.change(textarea, { target: { value: 'Some text' } });
-    const counter = screen.getByText(/9\/15/i);
-    expect(counter).toBeInTheDocument();
-  });
-
-  it('does not display a character counter when characterLimit is not set', () => {
-    render(<TextArea {...defaultProps} />);
-    const textarea = screen.getByPlaceholderText(/enter text/i);
-    fireEvent.change(textarea, { target: { value: 'Some text' } });
-    const counter = screen.queryByText(/\d+\/\d+/i);
-    expect(counter).not.toBeInTheDocument();
   });
 
   it('applies defaultValue correctly when component is uncontrolled', async () => {
@@ -114,11 +231,6 @@ describe('TextArea component', () => {
     expect(handleChange).toHaveBeenCalledTimes(1);
     expect(handleChange).toHaveBeenCalledWith(newValue);
     expect(textarea).toHaveValue(initialValue);
-
-    render(<TextArea {...defaultProps} value={newValue} onChange={handleChange} placeholder="Enter text" />);
-    const allAreas = screen.getAllByRole('textbox');
-    const newTextarea = allAreas[allAreas.length - 1];
-    expect(newTextarea).toHaveValue(newValue);
   });
 
   it('handles onChangeEvent correctly with controlled value', () => {

--- a/src/tedi/components/form/textarea/textarea.stories.tsx
+++ b/src/tedi/components/form/textarea/textarea.stories.tsx
@@ -52,7 +52,7 @@ const TemplateColumnWithStates: StoryFn<TemplateStateProps> = (args) => {
           </Col>
         </Row>
       ))}
-      <Row className="padding-14-16">
+      <Row>
         <Col width={2} className="display-flex align-items-center">
           <Text modifiers="bold">Success</Text>
         </Col>
@@ -67,7 +67,7 @@ const TemplateColumnWithStates: StoryFn<TemplateStateProps> = (args) => {
           />
         </Col>
       </Row>
-      <Row className="padding-14-16">
+      <Row>
         <Col width={2} className="display-flex align-items-center">
           <Text modifiers="bold">Error</Text>
         </Col>
@@ -188,5 +188,103 @@ export const DefaultValue: Story = {
     id: 'example-1',
     label: 'Label',
     defaultValue: 'Text value',
+  },
+};
+
+const TemplateHeights: StoryFn<TextAreaProps> = (args) => {
+  return (
+    <VerticalSpacing>
+      <Row>
+        <Col>
+          <Text modifiers="bold">Fixed Height (7.5rem default)</Text>
+        </Col>
+        <Col>
+          <TextArea
+            {...args}
+            id="fixed-height-default"
+            label="Label"
+            placeholder="This textarea has a fixed height of 7.5rem"
+          />
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Text modifiers="bold">Custom Fixed Height</Text>
+        </Col>
+        <Col>
+          <TextArea
+            {...args}
+            id="custom-height"
+            label="Label"
+            height="4rem"
+            placeholder="This textarea has a fixed height of 4rem"
+          />
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Text modifiers="bold">Auto Grow (minRows: 3, maxRows: 12)</Text>
+        </Col>
+        <Col>
+          <TextArea
+            {...args}
+            id="auto-grow"
+            label="Label"
+            autoGrow={true}
+            minRows={3}
+            maxRows={12}
+            placeholder="Type multiple lines to see it grow automatically"
+          />
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Text modifiers="bold">Auto Grow with Custom Rows</Text>
+        </Col>
+        <Col>
+          <TextArea
+            {...args}
+            id="auto-grow-custom"
+            label="Label"
+            autoGrow={true}
+            minRows={5}
+            maxRows={8}
+            placeholder="This will grow from 5 to 8 rows maximum"
+          />
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Text modifiers="bold">Auto Grow with Max Height</Text>
+        </Col>
+        <Col>
+          <TextArea
+            {...args}
+            id="auto-grow-max-height"
+            label="Label"
+            autoGrow={true}
+            maxHeight="200px"
+            minRows={3}
+            maxRows={12}
+            placeholder="This will grow but max height is limited to 200px"
+          />
+        </Col>
+      </Row>
+    </VerticalSpacing>
+  );
+};
+
+export const HeightExamples: Story = {
+  render: TemplateHeights,
+  parameters: {
+    docs: {
+      description: {
+        story: 'Examples showing different height configurations for TextArea',
+      },
+    },
   },
 };

--- a/src/tedi/components/form/textarea/textarea.tsx
+++ b/src/tedi/components/form/textarea/textarea.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames';
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useEffect, useRef } from 'react';
 
 import { FeedbackTextProps } from '../feedback-text/feedback-text';
 import { TextField, TextFieldForwardRef, TextFieldProps } from '../textfield/textfield';
@@ -10,6 +10,32 @@ export interface TextAreaProps extends TextFieldProps {
    * Maximum number of characters allowed in the textarea.
    */
   characterLimit?: number;
+  /**
+   * Enable automatic height adjustment based on content.
+   * @default false
+   */
+  autoGrow?: boolean;
+  /**
+   * Minimum number of rows (only used when autoGrow = true).
+   * @default 3
+   */
+  minRows?: number;
+  /**
+   * Maximum number of rows before scrolling (only used when autoGrow = true).
+   * @default 12
+   */
+  maxRows?: number;
+  /**
+   * Fixed height for the textarea (e.g. '200px', '12rem', 240).
+   * Ignored when autoGrow = true.
+   *
+   * @default 7.5rem
+   */
+  height?: string | number;
+  /**
+   * Maximum height when autoGrow is enabled.
+   */
+  maxHeight?: string | number;
 }
 
 export const TextArea = forwardRef<TextFieldForwardRef, TextAreaProps>((props, ref): JSX.Element => {
@@ -21,22 +47,133 @@ export const TextArea = forwardRef<TextFieldForwardRef, TextAreaProps>((props, r
     onChangeEvent,
     value: externalValue,
     defaultValue,
+    autoGrow = false,
+    minRows = 3,
+    maxRows = 12,
+    height = '7.5rem',
+    maxHeight,
     ...rest
   } = props;
+
   const [innerValue, setInnerValue] = React.useState(defaultValue ?? '');
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [textareaHeight, setTextareaHeight] = React.useState<string | number>('auto');
 
   const handleInputChange = React.useCallback(
     (inputValue: string) => {
       if (!externalValue && !(onChange || onChangeEvent)) {
         setInnerValue(inputValue);
       }
-
       onChange?.(inputValue);
     },
     [externalValue, onChange, onChangeEvent]
   );
 
   const value = React.useMemo(() => externalValue ?? innerValue, [externalValue, innerValue]);
+
+  const calculateHeight = React.useCallback(() => {
+    if (!autoGrow || !textareaRef.current) return;
+
+    const textarea = textareaRef.current;
+
+    const originalOverflow = textarea.style.overflow;
+
+    textarea.style.overflow = 'hidden';
+
+    const computedStyle = window.getComputedStyle(textarea);
+    const lineHeight = parseFloat(computedStyle.lineHeight);
+
+    const paddingTop = parseFloat(computedStyle.paddingTop);
+    const paddingBottom = parseFloat(computedStyle.paddingBottom);
+
+    const scrollHeight = textarea.scrollHeight;
+    const contentHeight = scrollHeight - paddingTop - paddingBottom;
+
+    let rowCount = Math.ceil(contentHeight / lineHeight);
+
+    rowCount = Math.min(Math.max(rowCount, minRows), maxRows);
+
+    const calculatedHeight = rowCount * lineHeight + paddingTop + paddingBottom;
+
+    textarea.style.height = `${calculatedHeight}px`;
+
+    textarea.style.overflow = originalOverflow;
+
+    if (rowCount >= maxRows) {
+      textarea.style.overflowY = 'auto';
+    } else {
+      textarea.style.overflowY = 'hidden';
+    }
+  }, [autoGrow, minRows, maxRows]);
+
+  useEffect(() => {
+    if (autoGrow) {
+      requestAnimationFrame(() => {
+        calculateHeight();
+      });
+    }
+  }, [value, autoGrow, calculateHeight]);
+
+  useEffect(() => {
+    if (autoGrow && textareaRef.current) {
+      calculateHeight();
+    }
+  }, [autoGrow, calculateHeight]);
+
+  const handleRef = React.useCallback(
+    (node: TextFieldForwardRef | null) => {
+      if (ref) {
+        if (typeof ref === 'function') {
+          ref(node);
+        } else {
+          ref.current = node;
+        }
+      }
+
+      if (node?.input && node.input instanceof HTMLTextAreaElement) {
+        textareaRef.current = node.input;
+
+        if (autoGrow) {
+          setTimeout(calculateHeight, 0);
+        }
+      }
+    },
+    [ref, autoGrow, calculateHeight]
+  );
+
+  const customInputProps = React.useMemo(() => {
+    if (autoGrow) {
+      return {
+        rows: minRows,
+        style: {
+          ...(maxHeight ? { maxHeight } : {}),
+          overflow: 'hidden',
+          height: textareaHeight,
+        },
+      };
+    } else {
+      return {
+        rows: minRows,
+        style: {
+          height: height,
+          ...(maxHeight ? { maxHeight } : {}),
+          overflow: 'auto',
+        },
+      };
+    }
+  }, [autoGrow, minRows, maxHeight, height, textareaHeight]);
+
+  useEffect(() => {
+    if (autoGrow && textareaRef.current) {
+      const updateHeight = () => {
+        if (textareaRef.current) {
+          setTextareaHeight(textareaRef.current.style.height);
+        }
+      };
+      updateHeight();
+    }
+  }, [autoGrow, value]);
+
   const charCount = value.length;
   const charCountHelper = characterLimit ? `${charCount}/${characterLimit}` : '';
   const combinedHelpers = [
@@ -56,15 +193,18 @@ export const TextArea = forwardRef<TextFieldForwardRef, TextAreaProps>((props, r
   return (
     <TextField
       {...rest}
-      ref={ref}
+      ref={handleRef}
       data-name="textarea"
-      inputClassName={styles['tedi-textarea__input']}
+      inputClassName={cn(styles['tedi-textarea__input'], {
+        [styles['tedi-textarea__input--auto-grow']]: autoGrow,
+      })}
       isTextArea={true}
       className={cn(styles['tedi-textarea'], className)}
       value={value}
       onChange={handleInputChange}
       onChangeEvent={onChangeEvent}
       helper={combinedHelpers as FeedbackTextProps[]}
+      input={customInputProps}
     />
   );
 });

--- a/src/tedi/components/form/textarea/textarea.tsx
+++ b/src/tedi/components/form/textarea/textarea.tsx
@@ -81,7 +81,14 @@ export const TextArea = forwardRef<TextFieldForwardRef, TextAreaProps>((props, r
     textarea.style.overflow = 'hidden';
 
     const computedStyle = window.getComputedStyle(textarea);
-    const lineHeight = parseFloat(computedStyle.lineHeight);
+
+    let lineHeight = parseFloat(computedStyle.lineHeight);
+
+    if (isNaN(lineHeight)) {
+      // Fallback: estimate from font-size (common ratio ~1.5)
+      const fontSize = parseFloat(computedStyle.fontSize) || 16;
+      lineHeight = fontSize * 1.5;
+    }
 
     const paddingTop = parseFloat(computedStyle.paddingTop);
     const paddingBottom = parseFloat(computedStyle.paddingBottom);
@@ -96,7 +103,6 @@ export const TextArea = forwardRef<TextFieldForwardRef, TextAreaProps>((props, r
     const calculatedHeight = rowCount * lineHeight + paddingTop + paddingBottom;
 
     textarea.style.height = `${calculatedHeight}px`;
-
     textarea.style.overflow = originalOverflow;
 
     if (rowCount >= maxRows) {
@@ -153,7 +159,6 @@ export const TextArea = forwardRef<TextFieldForwardRef, TextAreaProps>((props, r
       };
     } else {
       return {
-        rows: minRows,
         style: {
           height: height,
           ...(maxHeight ? { maxHeight } : {}),

--- a/src/tedi/components/form/textarea/textarea.tsx
+++ b/src/tedi/components/form/textarea/textarea.tsx
@@ -33,7 +33,10 @@ export interface TextAreaProps extends TextFieldProps {
    */
   height?: string | number;
   /**
-   * Maximum height when autoGrow is enabled.
+   * Maximum height of the textarea.
+   *
+   * - When `autoGrow` is enabled, this limits how tall the textarea can grow.
+   * - When `autoGrow` is disabled, this limits the fixed height.
    */
   maxHeight?: string | number;
 }
@@ -100,16 +103,12 @@ export const TextArea = forwardRef<TextFieldForwardRef, TextAreaProps>((props, r
 
     rowCount = Math.min(Math.max(rowCount, minRows), maxRows);
 
-    const calculatedHeight = rowCount * lineHeight + paddingTop + paddingBottom;
+    const nextHeight = `${rowCount * lineHeight + paddingTop + paddingBottom}px`;
+    textarea.style.height = nextHeight;
+    setTextareaHeight(nextHeight);
 
-    textarea.style.height = `${calculatedHeight}px`;
     textarea.style.overflow = originalOverflow;
-
-    if (rowCount >= maxRows) {
-      textarea.style.overflowY = 'auto';
-    } else {
-      textarea.style.overflowY = 'hidden';
-    }
+    textarea.style.overflowY = textarea.scrollHeight > textarea.clientHeight ? 'auto' : 'hidden';
   }, [autoGrow, minRows, maxRows]);
 
   useEffect(() => {
@@ -167,17 +166,6 @@ export const TextArea = forwardRef<TextFieldForwardRef, TextAreaProps>((props, r
       };
     }
   }, [autoGrow, minRows, maxHeight, height, textareaHeight]);
-
-  useEffect(() => {
-    if (autoGrow && textareaRef.current) {
-      const updateHeight = () => {
-        if (textareaRef.current) {
-          setTextareaHeight(textareaRef.current.style.height);
-        }
-      };
-      updateHeight();
-    }
-  }, [autoGrow, value]);
 
   const charCount = value.length;
   const charCountHelper = characterLimit ? `${charCount}/${characterLimit}` : '';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-grow textarea that adjusts height with configurable min/max rows and optional max-height.

* **Style**
  * Improved textarea sizing and typography; full-width box-sizing and right-aligned character counter. Added an auto-grow modifier that changes overflow/resize behavior.

* **Tests**
  * Expanded tests covering auto-grow behavior, height constraints, character counter, disabled/helper/validation states.

* **Documentation**
  * New story showcasing height and auto-grow examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->