### PR TITLE
feat(card): add more control to borderRadius usage, add examples #444

### DIFF
--- a/src/tedi/components/cards/card/card.module.scss
+++ b/src/tedi/components/cards/card/card.module.scss
@@ -22,7 +22,9 @@ $card-colors: (
 @mixin reset-corner($corner) {
   border-#{$corner}-radius: 0;
 
+  > .tedi-card__header:first-of-type,
   > .tedi-card__content:first-of-type,
+  > .tedi-card__header:last-child,
   > .tedi-card__content:last-child {
     border-#{$corner}-radius: 0;
   }

--- a/src/tedi/components/cards/card/card.module.scss
+++ b/src/tedi/components/cards/card/card.module.scss
@@ -19,14 +19,12 @@ $card-colors: (
   'warning-secondary': '--general-status-warning-background-dark',
 );
 
-@mixin border-radius-reset($sides...) {
-  @each $side in $sides {
-    border-#{$side}-radius: 0;
+@mixin reset-corner($corner) {
+  border-#{$corner}-radius: 0;
 
-    > .tedi-card__content:first-of-type,
-    > .tedi-card__content:last-child {
-      border-#{$side}-radius: 0;
-    }
+  > .tedi-card__content:first-of-type,
+  > .tedi-card__content:last-child {
+    border-#{$corner}-radius: 0;
   }
 }
 
@@ -76,20 +74,20 @@ $card-colors: (
     border: none;
   }
 
-  &--no-border-radius-top {
-    @include border-radius-reset(top-left, top-right);
+  &--no-radius-tl {
+    @include reset-corner(top-left);
   }
 
-  &--no-border-radius-right {
-    @include border-radius-reset(top-right, bottom-right);
+  &--no-radius-tr {
+    @include reset-corner(top-right);
   }
 
-  &--no-border-radius-bottom {
-    @include border-radius-reset(bottom-right, bottom-left);
+  &--no-radius-br {
+    @include reset-corner(bottom-right);
   }
 
-  &--no-border-radius-left {
-    @include border-radius-reset(bottom-left, top-left);
+  &--no-radius-bl {
+    @include reset-corner(bottom-left);
   }
 
   &--border-left,

--- a/src/tedi/components/cards/card/card.spec.tsx
+++ b/src/tedi/components/cards/card/card.spec.tsx
@@ -79,7 +79,7 @@ describe('Card Component', () => {
     expect(card).toHaveClass('tedi-card--borderless');
   });
 
-  it('applies custom border-radius styles', () => {
+  it('applies custom border-radius styles (top & left)', () => {
     render(
       <Card borderRadius={{ top: false, left: true }}>
         <CardHeader />
@@ -87,8 +87,22 @@ describe('Card Component', () => {
     );
 
     const card = screen.getByTestId('tedi-card');
-    expect(card).toHaveClass('tedi-card--no-border-radius-top');
-    expect(card).not.toHaveClass('tedi-card--no-border-radius-left');
+    expect(card).toHaveClass('tedi-card--no-radius-tl');
+    expect(card).toHaveClass('tedi-card--no-radius-tr');
+    expect(card).not.toHaveClass('tedi-card--no-radius-bl');
+    expect(card).not.toHaveClass('tedi-card--no-radius-br');
+  });
+
+  it('applies specific corner overrides correctly', () => {
+    render(
+      <Card borderRadius={{ bottom: false, bottomRight: true }}>
+        <CardHeader />
+      </Card>
+    );
+
+    const card = screen.getByTestId('tedi-card');
+    expect(card).toHaveClass('tedi-card--no-radius-bl');
+    expect(card).not.toHaveClass('tedi-card--no-radius-br');
   });
 
   it('combines custom `className` with default styles', () => {

--- a/src/tedi/components/cards/card/card.stories.tsx
+++ b/src/tedi/components/cards/card/card.stories.tsx
@@ -158,10 +158,6 @@ export const Backgrounds: Story = {
   render: BackgroundColorsTemplate,
 };
 
-export const BorderColors: Story = {
-  render: GeneralTemplate,
-};
-
 export const MultipleContent: Story = {
   render: GeneralTemplate,
 
@@ -220,15 +216,64 @@ export const Borderless: Story = {
   },
 };
 
-export const WithoutBorderRadius: Story = {
-  render: GeneralTemplate,
+export const BorderRadius = () => {
+  return (
+    <>
+      <Row>
+        <Col>
+          <Card>
+            <Card.Content>Default radius</Card.Content>
+          </Card>
+        </Col>
 
-  args: {
-    ...Default.args,
-    card: {
-      borderRadius: false,
-    },
-  },
+        <Col>
+          <Card borderRadius={false}>
+            <Card.Content>No radius</Card.Content>
+          </Card>
+        </Col>
+
+        <Col>
+          <Card borderRadius={{ top: false }}>
+            <Card.Content>No top radius</Card.Content>
+          </Card>
+        </Col>
+
+        <Col>
+          <Card borderRadius={{ bottom: false }}>
+            <Card.Content>No bottom radius</Card.Content>
+          </Card>
+        </Col>
+      </Row>
+
+      <Separator spacing={1.5} />
+
+      <Row>
+        <Col>
+          <Card borderRadius={{ left: false }}>
+            <Card.Content>No left radius</Card.Content>
+          </Card>
+        </Col>
+
+        <Col>
+          <Card borderRadius={{ right: false }}>
+            <Card.Content>No right radius</Card.Content>
+          </Card>
+        </Col>
+
+        <Col>
+          <Card borderRadius={{ topLeft: false }}>
+            <Card.Content>No top-left</Card.Content>
+          </Card>
+        </Col>
+
+        <Col>
+          <Card borderRadius={{ bottomRight: false }}>
+            <Card.Content>No bottom-right</Card.Content>
+          </Card>
+        </Col>
+      </Row>
+    </>
+  );
 };
 
 export const BreakpointProps: Story = {

--- a/src/tedi/components/cards/card/card.tsx
+++ b/src/tedi/components/cards/card/card.tsx
@@ -7,7 +7,14 @@ import { CardContent, CardContentProps } from './card-content/card-content';
 import { CardContext } from './card-context';
 import CardHeader from './card-header/card-header';
 import CardNotification from './card-notification/card-notification';
-import { CardBackground, CardBorderType, CardContentPaddingNumber, getCardBorderPlacementColor } from './utility';
+import {
+  BorderRadius,
+  CardBackground,
+  CardBorderType,
+  CardContentPaddingNumber,
+  getCardBorderPlacementColor,
+  resolveBorderRadius,
+} from './utility';
 
 export type CardContentPadding =
   | CardContentPaddingNumber
@@ -64,10 +71,20 @@ type CardBreakpointProps = {
    */
   className?: string;
   /**
-   * Follows the order in border-radius CSS property
-   * Top-left / Top-right / Bottom-right / Bottom-left
+   * Controls card border radius.
+   *
+   * Accepts `false` to remove all radius or an object to control sides or individual corners.
+   *
+   * Side values affect two corners while corner values take precedence.
+   *
+   * Examples:
+   * `false` → no radius
+   * `{ top:false }` → removes top corners
+   * `{ left:false }` → removes left corners
+   * `{ topLeft:false }` → removes one corner
+   * `{ bottom:false, bottomRight:true }` → corner override
    */
-  borderRadius?: false | { top?: boolean; right?: boolean; bottom?: boolean; left?: boolean };
+  borderRadius?: BorderRadius;
   /**
    * Remove border from card
    */
@@ -89,16 +106,19 @@ const CardComponent = forwardRef<HTMLDivElement, CardProps>((props, ref): JSX.El
 
   const [borderPlacement, borderColor] = getCardBorderPlacementColor(border);
 
+  const corners = resolveBorderRadius(borderRadius);
+
   const cardBEM = cn(
     styles['tedi-card'],
     {
       [styles[`tedi-card--border-${borderPlacement}`]]: borderPlacement,
       [styles[`tedi-card--border--${borderColor}`]]: borderColor,
       [styles['tedi-card--borderless']]: borderless,
-      [styles['tedi-card--no-border-radius-top']]: borderRadius === false || borderRadius?.top === false,
-      [styles['tedi-card--no-border-radius-right']]: borderRadius === false || borderRadius?.right === false,
-      [styles['tedi-card--no-border-radius-bottom']]: borderRadius === false || borderRadius?.bottom === false,
-      [styles['tedi-card--no-border-radius-left']]: borderRadius === false || borderRadius?.left === false,
+
+      [styles['tedi-card--no-radius-tl']]: !corners.topLeft,
+      [styles['tedi-card--no-radius-tr']]: !corners.topRight,
+      [styles['tedi-card--no-radius-br']]: !corners.bottomRight,
+      [styles['tedi-card--no-radius-bl']]: !corners.bottomLeft,
     },
     className
   );

--- a/src/tedi/components/cards/card/utility.ts
+++ b/src/tedi/components/cards/card/utility.ts
@@ -76,3 +76,57 @@ export const getPaddingCssVariables = (padding: CardContentProps['padding']) => 
     '--card-content-padding-left': `${left}rem`,
   };
 };
+
+export type BorderRadius =
+  | false
+  | {
+      top?: boolean;
+      right?: boolean;
+      bottom?: boolean;
+      left?: boolean;
+      topLeft?: boolean;
+      topRight?: boolean;
+      bottomRight?: boolean;
+      bottomLeft?: boolean;
+    };
+
+export type ResolvedCorners = {
+  topLeft: boolean;
+  topRight: boolean;
+  bottomRight: boolean;
+  bottomLeft: boolean;
+};
+
+export const resolveBorderRadius = (config?: BorderRadius): ResolvedCorners => {
+  if (config === false) {
+    return {
+      topLeft: false,
+      topRight: false,
+      bottomRight: false,
+      bottomLeft: false,
+    };
+  }
+
+  const { top, right, bottom, left, topLeft, topRight, bottomRight, bottomLeft } = config ?? {};
+
+  // default = true unless explicitly disabled
+  const sideTop = top !== false;
+  const sideRight = right !== false;
+  const sideBottom = bottom !== false;
+  const sideLeft = left !== false;
+
+  const resolved = {
+    topLeft: sideTop && sideLeft,
+    topRight: sideTop && sideRight,
+    bottomRight: sideBottom && sideRight,
+    bottomLeft: sideBottom && sideLeft,
+  };
+
+  // corner overrides have highest priority
+  return {
+    topLeft: topLeft ?? resolved.topLeft,
+    topRight: topRight ?? resolved.topRight,
+    bottomRight: bottomRight ?? resolved.bottomRight,
+    bottomLeft: bottomLeft ?? resolved.bottomLeft,
+  };
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Card supports corner-specific border-radius controls and a unified borderRadius prop type for finer control.

* **Tests**
  * Updated tests to cover corner-specific radius behavior and new class expectations.

* **Documentation**
  * Replaced prior examples with a new BorderRadius story showing full set of corner/side radius variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->