### PR TITLE
chore(storybook): attach standalone MDX pages as docs tabs and flatten ThemeProvider title #646

### DIFF
--- a/src/tedi/components/layout/sidenav/documentation.mdx
+++ b/src/tedi/components/layout/sidenav/documentation.mdx
@@ -1,6 +1,7 @@
-import { Meta } from '@storybook/addon-docs';
+import { Meta } from '@storybook/blocks';
+import * as SideNavStories from './sidenav.stories';
 
-<Meta title="TEDI-Ready/Layout/Sidenav/Documentation" />
+<Meta of={SideNavStories} name="Documentation" />
 
 # SideNav
 

--- a/src/tedi/components/misc/print/printing.mdx
+++ b/src/tedi/components/misc/print/printing.mdx
@@ -1,7 +1,7 @@
 import { Meta, Title, Subtitle, Unstyled } from '@storybook/blocks';
 import * as PrintStories from './print.stories';
 
-<Meta of={PrintStories} name="Printing" />
+<Meta of={PrintStories} name="Documentation" />
 
 # Printing in TEDI-Ready
 

--- a/src/tedi/components/misc/print/printing.mdx
+++ b/src/tedi/components/misc/print/printing.mdx
@@ -1,6 +1,7 @@
 import { Meta, Title, Subtitle, Unstyled } from '@storybook/blocks';
+import * as PrintStories from './print.stories';
 
-<Meta name="Printing" title="TEDI-Ready/Components/Helpers/Print/Documentation" />
+<Meta of={PrintStories} name="Printing" />
 
 # Printing in TEDI-Ready
 

--- a/src/tedi/components/navigation/pagination/usage-with-router.mdx
+++ b/src/tedi/components/navigation/pagination/usage-with-router.mdx
@@ -1,6 +1,7 @@
 import { Meta } from '@storybook/blocks';
+import * as PaginationStories from './pagination.stories';
 
-<Meta title="TEDI-Ready/Components/Navigation/Pagination/Usage with React Router" />
+<Meta of={PaginationStories} name="Usage with React Router" />
 
 # Usage with React Router
 

--- a/src/tedi/components/navigation/tabs/usage-with-router.mdx
+++ b/src/tedi/components/navigation/tabs/usage-with-router.mdx
@@ -1,6 +1,7 @@
 import { Meta } from '@storybook/blocks';
+import * as TabsStories from './tabs.stories';
 
-<Meta title="TEDI-Ready/Components/Navigation/Tabs/Usage with React Router" />
+<Meta of={TabsStories} name="Usage with React Router" />
 
 # Usage with React Router
 

--- a/src/tedi/components/notifications/toast/documentation.mdx
+++ b/src/tedi/components/notifications/toast/documentation.mdx
@@ -1,6 +1,7 @@
 import { Meta } from '@storybook/blocks';
+import * as ToastStories from './toast.stories';
 
-<Meta title="TEDI-Ready/Components/Notifications/Toast/Documentation" />
+<Meta of={ToastStories} name="Documentation" />
 
 # Toast
 

--- a/src/tedi/providers/label-provider/adding-labels.mdx
+++ b/src/tedi/providers/label-provider/adding-labels.mdx
@@ -1,6 +1,7 @@
 import { Meta } from '@storybook/blocks';
+import * as LabelProviderStories from './label-provider.stories';
 
-<Meta name="Labels" title="TEDI-Ready/Providers/LabelProvider/Adding labels" />
+<Meta of={LabelProviderStories} name="Adding labels" />
 
 # Adding labels
 

--- a/src/tedi/providers/label-provider/labels.mdx
+++ b/src/tedi/providers/label-provider/labels.mdx
@@ -1,8 +1,9 @@
 import { Meta, Title, Subtitle, Unstyled } from '@storybook/blocks';
+import * as LabelProviderStories from './label-provider.stories';
 
 import LabelsTable from './labels-table';
 
-<Meta name="Labels" title="TEDI-Ready/Providers/LabelProvider/Available labels" />
+<Meta of={LabelProviderStories} name="Available labels" />
 
 # Labels
 

--- a/src/tedi/providers/label-provider/migration-guide.mdx
+++ b/src/tedi/providers/label-provider/migration-guide.mdx
@@ -1,7 +1,8 @@
 import { Meta } from '@storybook/blocks';
+import * as LabelProviderStories from './label-provider.stories';
 import { Link } from '../../components/navigation/link/link.tsx';
 
-<Meta name="Labels" title="TEDI-Ready/Providers/LabelProvider/Migration guide" />
+<Meta of={LabelProviderStories} name="Migration guide" />
 
 # Migration guide
 

--- a/src/tedi/providers/theme-provider/theme-provider.stories.tsx
+++ b/src/tedi/providers/theme-provider/theme-provider.stories.tsx
@@ -7,7 +7,7 @@ import { Button } from '../../components/buttons/button/button';
 import { ThemeProvider } from './theme-provider';
 
 export default {
-  title: 'TEDI-Ready/Providers/ThemeProvider/ThemeProvider',
+  title: 'TEDI-Ready/Providers/ThemeProvider',
   component: ThemeProvider,
   decorators: [
     (Story, options) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation infrastructure and configuration for improved maintainability of component guides and provider documentation within the Storybook environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEDI-Design-System/react/pull/648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->