### PR TITLE
feat(collapse): add inverted variant #647

### DIFF
--- a/src/tedi/components/buttons/collapse/collapse.module.scss
+++ b/src/tedi/components/buttons/collapse/collapse.module.scss
@@ -166,4 +166,67 @@
   &--is-open > .tedi-collapse__title .tedi-collapse__icon {
     transform: rotate(180deg);
   }
+
+  &--inverted {
+    .tedi-collapse__icon--default {
+      color: var(--button-main-neutral-inverted-text-default);
+    }
+
+    .tedi-collapse__icon-wrapper--default {
+      border: 0;
+    }
+
+    .tedi-collapse__title {
+      .tedi-collapse__text {
+        color: var(--link-inverted-default);
+      }
+
+      &:hover {
+        .tedi-collapse__text {
+          color: var(--link-inverted-hover);
+        }
+
+        .tedi-collapse__icon--default {
+          color: var(--button-main-neutral-inverted-text-hover);
+        }
+      }
+
+      &:active {
+        .tedi-collapse__text {
+          color: var(--link-inverted-active);
+        }
+
+        .tedi-collapse__icon--default {
+          color: var(--button-main-neutral-inverted-text-active);
+        }
+      }
+
+      &:focus-visible {
+        outline-color: var(--button-main-neutral-inverted-border-focus);
+
+        .tedi-collapse__text {
+          color: var(--link-inverted-focus);
+        }
+
+        .tedi-collapse__icon--default {
+          color: var(--button-main-neutral-inverted-text-focus);
+        }
+      }
+    }
+
+    &.tedi-collapse--icon-only .tedi-collapse__title {
+      &:hover .tedi-collapse__icon-wrapper {
+        background: var(--button-main-neutral-inverted-icon-only-background-hover);
+      }
+
+      &:active .tedi-collapse__icon-wrapper {
+        background: var(--button-main-neutral-inverted-icon-only-background-active);
+      }
+
+      &:focus-visible .tedi-collapse__icon-wrapper {
+        background: var(--button-main-neutral-inverted-icon-only-background-focus);
+        outline-color: var(--button-main-neutral-inverted-border-focus);
+      }
+    }
+  }
 }

--- a/src/tedi/components/buttons/collapse/collapse.spec.tsx
+++ b/src/tedi/components/buttons/collapse/collapse.spec.tsx
@@ -150,4 +150,61 @@ describe('Collapse component with breakpoint support', () => {
 
     expect(screen.getByRole('button', { name: 'Toggle section' })).toBeInTheDocument();
   });
+
+  describe('inverted variant', () => {
+    it('does NOT apply the inverted modifier by default', () => {
+      const { container } = getComponent();
+      const root = container.querySelector('[data-name="collapse"]');
+      expect(root).not.toHaveClass('tedi-collapse--inverted');
+    });
+
+    it('applies the inverted modifier on the with-text variant', () => {
+      const { container } = getComponent({ inverted: true });
+      const root = container.querySelector('[data-name="collapse"]');
+      expect(root).toHaveClass('tedi-collapse--inverted');
+    });
+
+    it('keeps the with-text variant class set (no icon-only modifier) when inverted', () => {
+      const { container } = getComponent({ inverted: true });
+      const root = container.querySelector('[data-name="collapse"]');
+      expect(root).toHaveClass('tedi-collapse--inverted');
+      expect(root).not.toHaveClass('tedi-collapse--icon-only');
+    });
+
+    it('applies both the icon-only and inverted modifiers together', () => {
+      const { container } = render(
+        <Collapse id="collapse-inverted-icon" iconOnly inverted>
+          Content
+        </Collapse>
+      );
+      const root = container.querySelector('[data-name="collapse"]');
+      expect(root).toHaveClass('tedi-collapse--icon-only');
+      expect(root).toHaveClass('tedi-collapse--inverted');
+    });
+
+    it('composes the inverted modifier with the open state', () => {
+      const { container } = getComponent({ inverted: true, open: true });
+      const root = container.querySelector('[data-name="collapse"]');
+      expect(root).toHaveClass('tedi-collapse--inverted');
+      expect(root).toHaveClass('tedi-collapse--is-open');
+    });
+
+    it('composes the inverted modifier with the small size', () => {
+      const { container } = getComponent({ inverted: true, size: 'small' });
+      const root = container.querySelector('[data-name="collapse"]');
+      expect(root).toHaveClass('tedi-collapse--inverted');
+      expect(root).toHaveClass('tedi-collapse--small');
+    });
+
+    it('still toggles the open state on click when inverted', () => {
+      const { getByTestId } = getComponent({ inverted: true });
+      const content = getByTestId('collapse-inner');
+      const button = screen.getByRole('button', { name: /näita rohkem/i });
+      expect(content).toHaveStyle('height: 0px');
+      fireEvent.click(button);
+      // height transitions via AnimateHeight — the click commits the toggle,
+      // which is what we're actually verifying here.
+      expect(button).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
 });

--- a/src/tedi/components/buttons/collapse/collapse.spec.tsx
+++ b/src/tedi/components/buttons/collapse/collapse.spec.tsx
@@ -196,15 +196,19 @@ describe('Collapse component with breakpoint support', () => {
       expect(root).toHaveClass('tedi-collapse--small');
     });
 
+    it('drops the inverted modifier when paired with arrowType="secondary" (no inverted secondary form)', () => {
+      const { container } = getComponent({ inverted: true, arrowType: 'secondary' });
+      const root = container.querySelector('[data-name="collapse"]');
+      expect(root).not.toHaveClass('tedi-collapse--inverted');
+    });
+
     it('still toggles the open state on click when inverted', () => {
-      const { getByTestId } = getComponent({ inverted: true });
-      const content = getByTestId('collapse-inner');
+      getComponent({ inverted: true });
       const button = screen.getByRole('button', { name: /näita rohkem/i });
-      expect(content).toHaveStyle('height: 0px');
+      expect(screen.queryByRole('region', { name: /näita vähem/i })).not.toBeInTheDocument();
       fireEvent.click(button);
-      // height transitions via AnimateHeight — the click commits the toggle,
-      // which is what we're actually verifying here.
       expect(button).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByRole('region', { name: /näita vähem/i })).toBeInTheDocument();
     });
   });
 });

--- a/src/tedi/components/buttons/collapse/collapse.stories.tsx
+++ b/src/tedi/components/buttons/collapse/collapse.stories.tsx
@@ -39,7 +39,8 @@ type TemplateMultipleProps<Type = typeof buttonStateArray> = CollapseProps & {
 };
 
 const TemplateColumn: StoryFn<TemplateMultipleProps> = (args) => {
-  const { array, hideSizes, ...collapseProps } = args;
+  const { array, hideSizes, inverted, ...collapseProps } = args;
+  const labelColor = inverted ? 'white' : undefined;
 
   return (
     <>
@@ -47,11 +48,15 @@ const TemplateColumn: StoryFn<TemplateMultipleProps> = (args) => {
         <Row>
           <Col md={1}></Col>
           <Col>
-            <Text modifiers="bold">Default</Text>
+            <Text modifiers="bold" color={labelColor}>
+              Default
+            </Text>
           </Col>
           {!hideSizes && (
             <Col className="text-bold">
-              <Text modifiers="bold">Small</Text>
+              <Text modifiers="bold" color={labelColor}>
+                Small
+              </Text>
             </Col>
           )}
         </Row>
@@ -59,22 +64,24 @@ const TemplateColumn: StoryFn<TemplateMultipleProps> = (args) => {
         {array.map((value, key) => (
           <Row key={key}>
             <Col md={1} className="display-flex align-items-start">
-              <Text modifiers="bold">{value}</Text>
+              <Text modifiers="bold" color={labelColor}>
+                {value}
+              </Text>
             </Col>
             <Col className="display-flex align-items-start gap-3">
-              <Collapse {...collapseProps} id={value}>
+              <Collapse {...collapseProps} inverted={inverted} id={value}>
                 <>&nbsp;</>
               </Collapse>
-              <Collapse {...collapseProps} id={value} open>
+              <Collapse {...collapseProps} inverted={inverted} id={value} open>
                 <>&nbsp;</>
               </Collapse>
             </Col>
             {!hideSizes && (
               <Col className="display-flex align-items-start gap-3">
-                <Collapse {...collapseProps} id={value} size="small">
+                <Collapse {...collapseProps} inverted={inverted} id={value} size="small">
                   <>&nbsp;</>
                 </Collapse>
-                <Collapse {...collapseProps} id={value} open size="small">
+                <Collapse {...collapseProps} inverted={inverted} id={value} open size="small">
                   <>&nbsp;</>
                 </Collapse>
               </Col>
@@ -114,6 +121,41 @@ export const IconOnly = {
       active: '#Active__trigger',
       focusVisible: '#Focus__trigger',
     },
+  },
+};
+
+export const WithTextInverted = {
+  render: TemplateColumn,
+  args: {
+    array: buttonStateArray,
+    visualType: 'primary',
+    inverted: true,
+  },
+  parameters: {
+    pseudo: {
+      hover: '#Hover__trigger',
+      active: '#Active__trigger',
+      focusVisible: '#Focus__trigger',
+    },
+    backgrounds: { default: 'brand' },
+  },
+};
+
+export const IconOnlyInverted = {
+  render: TemplateColumn,
+  args: {
+    array: buttonStateArray,
+    visualType: 'primary',
+    iconOnly: true,
+    inverted: true,
+  },
+  parameters: {
+    pseudo: {
+      hover: '#Hover__trigger',
+      active: '#Active__trigger',
+      focusVisible: '#Focus__trigger',
+    },
+    backgrounds: { default: 'brand' },
   },
 };
 

--- a/src/tedi/components/buttons/collapse/collapse.tsx
+++ b/src/tedi/components/buttons/collapse/collapse.tsx
@@ -57,6 +57,14 @@ type CollapseBreakpointProps = {
    * @default false
    */
   iconOnly?: boolean;
+  /**
+   * Inverted color palette — flips the link / icon colors to their
+   * inverted-surface equivalents (white text + icon), for use on top of dark
+   * backgrounds. Pairs with both the with-text and icon-only variants; the
+   * secondary-arrow style has no inverted form in the design.
+   * @default false
+   */
+  inverted?: boolean;
 };
 
 export interface CollapseProps extends BreakpointSupport<CollapseBreakpointProps> {
@@ -116,6 +124,7 @@ export const Collapse = (props: CollapseProps): JSX.Element => {
     underline = true,
     toggleLabel,
     iconOnly = false,
+    inverted = false,
     ...rest
   } = getCurrentBreakpointProps<CollapseProps>(props);
 
@@ -138,6 +147,7 @@ export const Collapse = (props: CollapseProps): JSX.Element => {
     size === 'small' && styles['tedi-collapse--small'],
     isOpen && styles['tedi-collapse--is-open'],
     isIconOnly && styles['tedi-collapse--icon-only'],
+    inverted && styles['tedi-collapse--inverted'],
     styles[`tedi-collapse--arrow-${arrowType}`],
     className
   );

--- a/src/tedi/components/buttons/collapse/collapse.tsx
+++ b/src/tedi/components/buttons/collapse/collapse.tsx
@@ -141,13 +141,14 @@ export const Collapse = (props: CollapseProps): JSX.Element => {
   );
 
   const isIconOnly = iconOnly === true && !title;
+  const isInverted = inverted && arrowType !== 'secondary';
 
   const CollapseBEM = cn(
     styles['tedi-collapse'],
     size === 'small' && styles['tedi-collapse--small'],
     isOpen && styles['tedi-collapse--is-open'],
     isIconOnly && styles['tedi-collapse--icon-only'],
-    inverted && styles['tedi-collapse--inverted'],
+    isInverted && styles['tedi-collapse--inverted'],
     styles[`tedi-collapse--arrow-${arrowType}`],
     className
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inverted variant to the Collapse component for use with inverted color schemes
  * The inverted styling adjusts text and icon colors, hover states, and focus indicators
  * The new variant is compatible with all existing Collapse configurations including icon-only mode, various sizes, and open/closed states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->