### PR TITLE
feat(alert): add action prop to replace ClosingButton if necessary #552

### DIFF
--- a/src/tedi/components/notifications/alert/alert.module.scss
+++ b/src/tedi/components/notifications/alert/alert.module.scss
@@ -1,3 +1,5 @@
+@use '@tedi-design-system/core/bootstrap-utility/breakpoints';
+
 @mixin alert-variant($background, $border) {
   color: var(--general-text-primary);
   background-color: $background;
@@ -64,6 +66,16 @@
     border-right: none;
     border-left: none;
     border-radius: 0;
+  }
+
+  &--has-action {
+    @include breakpoints.media-breakpoint-down(sm) {
+      [data-name='row'] {
+        flex-direction: column;
+        gap: var(--layout-grid-gutters-12);
+        align-items: flex-start;
+      }
+    }
   }
 }
 

--- a/src/tedi/components/notifications/alert/alert.spec.tsx
+++ b/src/tedi/components/notifications/alert/alert.spec.tsx
@@ -81,6 +81,23 @@ describe('Alert component', () => {
     expect(closeButton).not.toBeInTheDocument();
   });
 
+  it('renders the `action` slot in place of the default close button', () => {
+    const onCloseMock = jest.fn();
+    render(
+      <Alert onClose={onCloseMock} action={<button type="button">Open profile</button>}>
+        Custom action
+      </Alert>
+    );
+
+    expect(screen.getByRole('button', { name: 'Open profile' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the `action` slot even without `onClose`', () => {
+    render(<Alert action={<a href="/x">Read more</a>}>Custom action only</Alert>);
+    expect(screen.getByRole('link', { name: 'Read more' })).toBeInTheDocument();
+  });
+
   it('sets aria-live based on role prop', () => {
     render(<Alert role="status">Status Alert</Alert>);
 

--- a/src/tedi/components/notifications/alert/alert.stories.tsx
+++ b/src/tedi/components/notifications/alert/alert.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryFn, StoryObj } from '@storybook/react';
 
 import { Text } from '../../base/typography/text/text';
+import Button from '../../buttons/button/button';
 import { Col, Row } from '../../layout/grid';
 import { VerticalSpacing } from '../../layout/vertical-spacing';
 import Link from '../../navigation/link/link';
@@ -190,5 +191,27 @@ export const WithTitleLongTextAndClosingButton: Story = {
   },
   render: (args) => {
     return <Alert {...args} />;
+  },
+};
+
+/**
+ * The `action` prop fills the right slot of the alert with any ReactNode —
+ * here a CTA button that takes the user somewhere relevant.
+ *
+ * **Note:** when `action` is set, the default close button is ignored even if
+ * `onClose` is also passed. The slot is single-purpose — if you need both a
+ * CTA and a dismiss control, render both inside `action` (e.g. wrap them in
+ * a flex `<div>` with a small gap).
+ */
+export const WithActionButton: Story = {
+  args: {
+    type: 'warning',
+    icon: 'warning',
+    children: 'Your account is missing a profile photo — add one so colleagues can recognise you in shared documents.',
+    action: (
+      <Button visualType="secondary" iconRight="arrow_forward">
+        Open profile
+      </Button>
+    ),
   },
 };

--- a/src/tedi/components/notifications/alert/alert.tsx
+++ b/src/tedi/components/notifications/alert/alert.tsx
@@ -184,4 +184,6 @@ export const Alert = (props: AlertProps): JSX.Element | null => {
   ) : null;
 };
 
+Alert.displayName = 'Alert';
+
 export default Alert;

--- a/src/tedi/components/notifications/alert/alert.tsx
+++ b/src/tedi/components/notifications/alert/alert.tsx
@@ -64,8 +64,18 @@ export interface AlertProps extends BreakpointSupport<AlertBreakpointProps> {
    * Callback function triggered when the close button is clicked.
    * Adding this handler renders a close button in the alert.
    * Useful for dismissible alerts.
+   *
+   * Ignored when `action` is also set — the consumer's slot wins, and is
+   * responsible for any close affordance it wants to expose.
    */
   onClose?: () => void;
+  /**
+   * Custom content for the right-side slot of the alert (e.g. a CTA button,
+   * a link, or a small icon stack). Replaces the default close button when
+   * provided. Use this instead of squeezing buttons into `children` so the
+   * layout slot is reserved and aligned consistently.
+   */
+  action?: React.ReactNode;
   /**
    * The ARIA role of the alert, informing screen readers about the alert's purpose.
    * Options:
@@ -101,6 +111,7 @@ export const Alert = (props: AlertProps): JSX.Element | null => {
     type = 'info',
     icon,
     onClose,
+    action,
     isGlobal = false,
     noSideBorders = false,
     titleElement = 'h3',
@@ -115,6 +126,7 @@ export const Alert = (props: AlertProps): JSX.Element | null => {
     {
       [styles['tedi-alert--global']]: isGlobal,
       [styles['tedi-alert--no-side-borders']]: noSideBorders,
+      [styles['tedi-alert--has-action']]: Boolean(action),
     },
     className
   );
@@ -156,10 +168,14 @@ export const Alert = (props: AlertProps): JSX.Element | null => {
               )}
             </div>
           </Col>
-          {onClose && (
-            <Col width="auto">
-              <ClosingButton onClick={onClose} iconSize={18} />
-            </Col>
+          {action ? (
+            <Col width="auto">{action}</Col>
+          ) : (
+            onClose && (
+              <Col width="auto">
+                <ClosingButton onClick={onClose} iconSize={18} />
+              </Col>
+            )
           )}
         </Row>
         {title && children && <div className="tedi-alert__content-wrapper">{children}</div>}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alerts now support custom action content on the right side, which takes precedence over the default close button
  * Added responsive styling for alerts with actions

* **Tests**
  * Added test coverage for alert action slot behavior

* **Documentation**
  * Added Storybook story demonstrating action button usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->