### PR TITLE
fix(input-group,empty-state): design review fixes #667

### DIFF
--- a/src/community/components/placeholder/placeholder.stories.tsx
+++ b/src/community/components/placeholder/placeholder.stories.tsx
@@ -6,9 +6,18 @@ import { Card, CardContent } from '../card';
 import CardHeader from '../card/card-header/card-header';
 import Placeholder from './placeholder';
 
+/**
+ * **⚠️ DEPRECATED** — use `EmptyState` from `@tedi-design-system/react/tedi` instead. This
+ * Community component is no longer maintained and will be removed in a future release.
+ */
 const meta: Meta<typeof Placeholder> = {
   component: Placeholder,
   title: 'Community/Placeholder',
+  parameters: {
+    status: {
+      type: ['deprecated', 'ExistsInTediReady'],
+    },
+  },
 };
 
 export default meta;

--- a/src/community/components/placeholder/placeholder.tsx
+++ b/src/community/components/placeholder/placeholder.tsx
@@ -8,6 +8,9 @@ import Print from '../../../tedi/components/misc/print/print';
 import useLayout from '../../helpers/hooks/use-layout';
 import { Card, CardContent, CardProps } from '../card';
 
+/**
+ * @deprecated Use EmptyState from `@tedi-design-system/react/tedi` instead.
+ */
 export interface PlaceholderProps {
   /**
    * Placeholder block content
@@ -38,6 +41,8 @@ export interface PlaceholderProps {
 }
 
 /**
+ * @deprecated Use EmptyState from `@tedi-design-system/react/tedi` instead.
+ *
  * Placeholder is used to indicate, that there is no data to show. It can be used on its own or inside other components, like a `<CardContent>`.
  * Other components also use it internally for displaying empty state. (E.g. `<Table>`)
  */

--- a/src/tedi/components/form/input-group/components/input/input.spec.tsx
+++ b/src/tedi/components/form/input-group/components/input/input.spec.tsx
@@ -75,10 +75,10 @@ describe('InputGroup.Input', () => {
 
   it('propagates invalid and wrapperClassName to a non-intrinsic child', () => {
     const Probe = ({ invalid, wrapperClassName }: { invalid?: boolean; wrapperClassName?: string }) => (
-      <div data-testid="probe" data-invalid={String(!!invalid)} className={wrapperClassName} />
+      <div role="group" aria-label="probe" data-invalid={String(!!invalid)} className={wrapperClassName} />
     );
 
-    const { getByTestId } = render(
+    const { getByRole } = render(
       <InputGroup invalid id="test-group" label="Test Group">
         <InputGroup.Input>
           <Probe />
@@ -86,17 +86,17 @@ describe('InputGroup.Input', () => {
       </InputGroup>
     );
 
-    const probe = getByTestId('probe');
+    const probe = getByRole('group', { name: 'probe' });
     expect(probe).toHaveAttribute('data-invalid', 'true');
     expect(probe).toHaveClass('tedi-input-group__input');
   });
 
   it('keeps a non-intrinsic child invalid and merges its wrapperClassName when the group is valid', () => {
     const Probe = ({ invalid, wrapperClassName }: { invalid?: boolean; wrapperClassName?: string }) => (
-      <div data-testid="probe" data-invalid={String(!!invalid)} className={wrapperClassName} />
+      <div role="group" aria-label="probe" data-invalid={String(!!invalid)} className={wrapperClassName} />
     );
 
-    const { getByTestId } = render(
+    const { getByRole } = render(
       <InputGroup id="test-group" label="Test Group">
         <InputGroup.Input>
           <Probe invalid wrapperClassName="own-wrapper" />
@@ -104,7 +104,7 @@ describe('InputGroup.Input', () => {
       </InputGroup>
     );
 
-    const probe = getByTestId('probe');
+    const probe = getByRole('group', { name: 'probe' });
     expect(probe).toHaveAttribute('data-invalid', 'true');
     expect(probe).toHaveClass('own-wrapper');
     expect(probe).toHaveClass('tedi-input-group__input');

--- a/src/tedi/components/form/input-group/components/input/input.spec.tsx
+++ b/src/tedi/components/form/input-group/components/input/input.spec.tsx
@@ -37,6 +37,79 @@ describe('InputGroup.Input', () => {
     expect(getByLabelText('plain')).toBeDisabled();
   });
 
+  it('sets aria-invalid on an intrinsic child when the group is invalid', () => {
+    const { getByLabelText } = render(
+      <InputGroup invalid id="test-group" label="Test Group">
+        <InputGroup.Input>
+          <input aria-label="plain" />
+        </InputGroup.Input>
+      </InputGroup>
+    );
+
+    expect(getByLabelText('plain')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('does not set aria-invalid on an intrinsic child when the group is valid', () => {
+    const { getByLabelText } = render(
+      <InputGroup id="test-group" label="Test Group">
+        <InputGroup.Input>
+          <input aria-label="plain" />
+        </InputGroup.Input>
+      </InputGroup>
+    );
+
+    expect(getByLabelText('plain')).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('keeps the child aria-invalid when the group is valid', () => {
+    const { getByLabelText } = render(
+      <InputGroup id="test-group" label="Test Group">
+        <InputGroup.Input>
+          <input aria-label="plain" aria-invalid />
+        </InputGroup.Input>
+      </InputGroup>
+    );
+
+    expect(getByLabelText('plain')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('propagates invalid and wrapperClassName to a non-intrinsic child', () => {
+    const Probe = ({ invalid, wrapperClassName }: { invalid?: boolean; wrapperClassName?: string }) => (
+      <div data-testid="probe" data-invalid={String(!!invalid)} className={wrapperClassName} />
+    );
+
+    const { getByTestId } = render(
+      <InputGroup invalid id="test-group" label="Test Group">
+        <InputGroup.Input>
+          <Probe />
+        </InputGroup.Input>
+      </InputGroup>
+    );
+
+    const probe = getByTestId('probe');
+    expect(probe).toHaveAttribute('data-invalid', 'true');
+    expect(probe).toHaveClass('tedi-input-group__input');
+  });
+
+  it('keeps a non-intrinsic child invalid and merges its wrapperClassName when the group is valid', () => {
+    const Probe = ({ invalid, wrapperClassName }: { invalid?: boolean; wrapperClassName?: string }) => (
+      <div data-testid="probe" data-invalid={String(!!invalid)} className={wrapperClassName} />
+    );
+
+    const { getByTestId } = render(
+      <InputGroup id="test-group" label="Test Group">
+        <InputGroup.Input>
+          <Probe invalid wrapperClassName="own-wrapper" />
+        </InputGroup.Input>
+      </InputGroup>
+    );
+
+    const probe = getByTestId('probe');
+    expect(probe).toHaveAttribute('data-invalid', 'true');
+    expect(probe).toHaveClass('own-wrapper');
+    expect(probe).toHaveClass('tedi-input-group__input');
+  });
+
   it('uses the InputGroup inputId when the child has no id', () => {
     const { getByLabelText } = render(
       <InputGroup id="group-id" label="Test Group">

--- a/src/tedi/components/form/input-group/components/input/input.tsx
+++ b/src/tedi/components/form/input-group/components/input/input.tsx
@@ -24,7 +24,7 @@ export interface InputProps {
 }
 
 export const Input = ({ children }: InputProps) => {
-  const { disabled, inputId } = useInputGroup();
+  const { disabled, invalid, inputId } = useInputGroup();
 
   if (!React.isValidElement(children)) return children;
 
@@ -34,9 +34,12 @@ export const Input = ({ children }: InputProps) => {
     disabled: disabled || children.props.disabled,
     id: children.props.id ?? inputId,
     className: classNames(children.props.className, styles['tedi-input-group__input']),
-    ...(!isIntrinsicChild && {
-      wrapperClassName: classNames(children.props.wrapperClassName, styles['tedi-input-group__input']),
-    }),
+    ...(isIntrinsicChild
+      ? { 'aria-invalid': invalid || children.props['aria-invalid'] || undefined }
+      : {
+          invalid: invalid || children.props.invalid,
+          wrapperClassName: classNames(children.props.wrapperClassName, styles['tedi-input-group__input']),
+        }),
   };
 
   return React.cloneElement(children, extraProps);

--- a/src/tedi/components/form/input-group/components/prefix/prefix.spec.tsx
+++ b/src/tedi/components/form/input-group/components/prefix/prefix.spec.tsx
@@ -49,6 +49,36 @@ describe('InputGroup.Prefix', () => {
     expect(prefix).toHaveAttribute('aria-disabled', 'true');
   });
 
+  it('propagates the disabled state to an interactive child element', () => {
+    const { getByRole } = render(
+      <InputGroup disabled id="test-group" label="Test Group">
+        <InputGroup.Prefix>
+          <button type="button">Go</button>
+        </InputGroup.Prefix>
+        <InputGroup.Input>
+          <input aria-label="plain" />
+        </InputGroup.Input>
+      </InputGroup>
+    );
+
+    expect(getByRole('button', { name: 'Go' })).toBeDisabled();
+  });
+
+  it('leaves an interactive child enabled when the group is not disabled', () => {
+    const { getByRole } = render(
+      <InputGroup id="test-group" label="Test Group">
+        <InputGroup.Prefix>
+          <button type="button">Go</button>
+        </InputGroup.Prefix>
+        <InputGroup.Input>
+          <input aria-label="plain" />
+        </InputGroup.Input>
+      </InputGroup>
+    );
+
+    expect(getByRole('button', { name: 'Go' })).toBeEnabled();
+  });
+
   it('unregisters from the InputGroup when it is removed', () => {
     const { container, rerender } = render(
       <InputGroup id="test-group" label="Test Group">

--- a/src/tedi/components/form/input-group/components/prefix/prefix.tsx
+++ b/src/tedi/components/form/input-group/components/prefix/prefix.tsx
@@ -31,13 +31,9 @@ export const Prefix = ({ children, className, ...props }: PrefixProps) => {
 
   const isText = typeof children === 'string' || typeof children === 'number';
 
-  // Propagate the group's disabled state to an interactive child (e.g. a Button addon) so it
-  // becomes truly disabled and uses its own disabled styling rather than its enabled colours.
   const content =
     disabled && isValidElement(children)
-      ? cloneElement(children as ReactElement<{ disabled?: boolean }>, {
-          disabled: disabled || children.props.disabled,
-        })
+      ? cloneElement(children as ReactElement<{ disabled?: boolean }>, { disabled: true })
       : children;
 
   return (

--- a/src/tedi/components/form/input-group/components/prefix/prefix.tsx
+++ b/src/tedi/components/form/input-group/components/prefix/prefix.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { ReactNode, useEffect } from 'react';
+import { cloneElement, isValidElement, ReactElement, ReactNode, useEffect } from 'react';
 
 import { useInputGroup } from '../../input-group';
 import styles from '../../input-group.module.scss';
@@ -31,6 +31,15 @@ export const Prefix = ({ children, className, ...props }: PrefixProps) => {
 
   const isText = typeof children === 'string' || typeof children === 'number';
 
+  // Propagate the group's disabled state to an interactive child (e.g. a Button addon) so it
+  // becomes truly disabled and uses its own disabled styling rather than its enabled colours.
+  const content =
+    disabled && isValidElement(children)
+      ? cloneElement(children as ReactElement<{ disabled?: boolean }>, {
+          disabled: disabled || children.props.disabled,
+        })
+      : children;
+
   return (
     <div
       {...props}
@@ -41,7 +50,7 @@ export const Prefix = ({ children, className, ...props }: PrefixProps) => {
       )}
       aria-disabled={disabled}
     >
-      {children}
+      {content}
     </div>
   );
 };

--- a/src/tedi/components/form/input-group/components/suffix/suffix.spec.tsx
+++ b/src/tedi/components/form/input-group/components/suffix/suffix.spec.tsx
@@ -49,6 +49,36 @@ describe('InputGroup.Suffix', () => {
     expect(suffix).toHaveAttribute('aria-disabled', 'true');
   });
 
+  it('propagates the disabled state to an interactive child element', () => {
+    const { getByRole } = render(
+      <InputGroup disabled id="test-group" label="Test Group">
+        <InputGroup.Input>
+          <input aria-label="plain" />
+        </InputGroup.Input>
+        <InputGroup.Suffix>
+          <button type="button">Apply</button>
+        </InputGroup.Suffix>
+      </InputGroup>
+    );
+
+    expect(getByRole('button', { name: 'Apply' })).toBeDisabled();
+  });
+
+  it('leaves an interactive child enabled when the group is not disabled', () => {
+    const { getByRole } = render(
+      <InputGroup id="test-group" label="Test Group">
+        <InputGroup.Input>
+          <input aria-label="plain" />
+        </InputGroup.Input>
+        <InputGroup.Suffix>
+          <button type="button">Apply</button>
+        </InputGroup.Suffix>
+      </InputGroup>
+    );
+
+    expect(getByRole('button', { name: 'Apply' })).toBeEnabled();
+  });
+
   it('unregisters from the InputGroup when it is removed', () => {
     const { container, rerender } = render(
       <InputGroup id="test-group" label="Test Group">

--- a/src/tedi/components/form/input-group/components/suffix/suffix.tsx
+++ b/src/tedi/components/form/input-group/components/suffix/suffix.tsx
@@ -31,13 +31,9 @@ export const Suffix = ({ children, className, ...props }: SuffixProps) => {
 
   const isText = typeof children === 'string' || typeof children === 'number';
 
-  // Propagate the group's disabled state to an interactive child (e.g. a Button addon) so it
-  // becomes truly disabled and uses its own disabled styling rather than its enabled colours.
   const content =
     disabled && isValidElement(children)
-      ? cloneElement(children as ReactElement<{ disabled?: boolean }>, {
-          disabled: disabled || children.props.disabled,
-        })
+      ? cloneElement(children as ReactElement<{ disabled?: boolean }>, { disabled: true })
       : children;
 
   return (

--- a/src/tedi/components/form/input-group/components/suffix/suffix.tsx
+++ b/src/tedi/components/form/input-group/components/suffix/suffix.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { ReactNode, useEffect } from 'react';
+import { cloneElement, isValidElement, ReactElement, ReactNode, useEffect } from 'react';
 
 import { useInputGroup } from '../../input-group';
 import styles from '../../input-group.module.scss';
@@ -31,6 +31,15 @@ export const Suffix = ({ children, className, ...props }: SuffixProps) => {
 
   const isText = typeof children === 'string' || typeof children === 'number';
 
+  // Propagate the group's disabled state to an interactive child (e.g. a Button addon) so it
+  // becomes truly disabled and uses its own disabled styling rather than its enabled colours.
+  const content =
+    disabled && isValidElement(children)
+      ? cloneElement(children as ReactElement<{ disabled?: boolean }>, {
+          disabled: disabled || children.props.disabled,
+        })
+      : children;
+
   return (
     <div
       {...props}
@@ -41,7 +50,7 @@ export const Suffix = ({ children, className, ...props }: SuffixProps) => {
       )}
       aria-disabled={disabled}
     >
-      {children}
+      {content}
     </div>
   );
 };

--- a/src/tedi/components/form/input-group/input-group.module.scss
+++ b/src/tedi/components/form/input-group/input-group.module.scss
@@ -1,6 +1,10 @@
 .tedi-input-group {
-  display: inline-flex;
   width: 100%;
+
+  &__row {
+    display: inline-flex;
+    width: 100%;
+  }
 
   &__prefix,
   &__suffix,
@@ -122,6 +126,7 @@
   &--disabled {
     .tedi-input-group__prefix,
     .tedi-input-group__suffix {
+      color: var(--general-text-disabled);
       background-color: var(--form-general-background-disabled);
       border-color: var(--form-input-border-disabled);
     }

--- a/src/tedi/components/form/input-group/input-group.stories.tsx
+++ b/src/tedi/components/form/input-group/input-group.stories.tsx
@@ -408,17 +408,17 @@ const TemplateColumnWithStates: StoryFn<TemplateStateProps> = (args) => {
           <Text modifiers="bold">Error</Text>
         </Col>
         <Col>
-          <InputGroup label="Label" id="state-example" helper={{ text: 'Feedback text', type: 'error' }}>
+          <InputGroup label="Label" id="state-example" invalid helper={{ text: 'Feedback text', type: 'error' }}>
             <InputGroup.Prefix>Street</InputGroup.Prefix>
             <InputGroup.Input>
-              <Field invalid />
+              <Field />
             </InputGroup.Input>
           </InputGroup>
         </Col>
         <Col>
-          <InputGroup label="Label" id="state-example" helper={{ text: 'Feedback text', type: 'error' }}>
+          <InputGroup label="Label" id="state-example" invalid helper={{ text: 'Feedback text', type: 'error' }}>
             <InputGroup.Input>
-              <Field invalid />
+              <Field />
             </InputGroup.Input>
             <InputGroup.Suffix>EUR</InputGroup.Suffix>
           </InputGroup>
@@ -456,6 +456,42 @@ export const WithButtonAddons: Story = {
         <InputGroup.Suffix>
           <Button>Apply</Button>
         </InputGroup.Suffix>
+      </InputGroup>
+
+      <InputGroup {...args} disabled id="input-group-button-disabled" label="Promo code (disabled)">
+        <InputGroup.Input>
+          <Field placeholder="Enter promo code" />
+        </InputGroup.Input>
+        <InputGroup.Suffix>
+          <Button>Apply</Button>
+        </InputGroup.Suffix>
+      </InputGroup>
+    </VerticalSpacing>
+  ),
+};
+
+/**
+ * Feedback text is rendered below the group via the `helper` prop, which accepts the same
+ * shape as `FeedbackText` — a single message or an array. Use `type: 'hint'` for guidance and
+ * `type: 'error'` for validation messages. Pair an error message with the `invalid` prop so the
+ * whole group (addon borders + the inner control) reflects the error state — `invalid` is
+ * propagated to the wrapped control automatically, so you don't set it on the child too.
+ */
+export const WithFeedbackText: Story = {
+  render: () => (
+    <VerticalSpacing size={1}>
+      <InputGroup label="Amount" id="feedback-hint" helper={{ text: 'Enter the amount in euros', type: 'hint' }}>
+        <InputGroup.Input>
+          <Field placeholder="0.00" />
+        </InputGroup.Input>
+        <InputGroup.Suffix>EUR</InputGroup.Suffix>
+      </InputGroup>
+
+      <InputGroup label="Amount" id="feedback-error" invalid helper={{ text: 'This field is required', type: 'error' }}>
+        <InputGroup.Input>
+          <Field placeholder="0.00" />
+        </InputGroup.Input>
+        <InputGroup.Suffix>EUR</InputGroup.Suffix>
       </InputGroup>
     </VerticalSpacing>
   ),

--- a/src/tedi/components/form/input-group/input-group.tsx
+++ b/src/tedi/components/form/input-group/input-group.tsx
@@ -40,6 +40,13 @@ export interface InputGroupProps extends FormLabelProps {
    * to the input and any interactive prefix/suffix elements.
    */
   disabled?: boolean;
+  /**
+   * Marks the whole group as invalid. Applies the error border to the
+   * prefix/suffix addons and propagates `invalid` down to the inner form
+   * control, so you don't have to set it on the child as well. Pair with an
+   * error `helper` message.
+   */
+  invalid?: boolean;
 }
 
 export interface InputGroupForwardRef {
@@ -79,6 +86,12 @@ export type InputGroupContextValue = {
    * behavior and styling.
    */
   disabled?: boolean;
+  /**
+   * Invalid state inherited from InputGroup.
+   * Consumed by Input to propagate `invalid` (or `aria-invalid`) to the
+   * wrapped form control.
+   */
+  invalid?: boolean;
   /*
    * Indicates if the InputGroup has an external label (i.e. FormLabel rendered by InputGroup).
    * This is used by child components to determine if they should render their own label or not.
@@ -107,7 +120,7 @@ export const useOptionalInputGroup = () => {
 };
 
 export const InputGroupBase = forwardRef<InputGroupForwardRef, InputGroupProps>(
-  ({ className, addons = true, helper, label, children, disabled, id, ...labelProps }, ref) => {
+  ({ className, addons = true, helper, label, children, disabled, invalid, id, ...labelProps }, ref) => {
     const rootRef = React.useRef<HTMLDivElement>(null);
     const generatedId = React.useId();
 
@@ -127,6 +140,7 @@ export const InputGroupBase = forwardRef<InputGroupForwardRef, InputGroupProps>(
         hasPrefix,
         hasSuffix,
         disabled,
+        invalid,
         hasExternalLabel: !!label,
         inputId,
         registerPrefix: () => setHasPrefix(true),
@@ -134,7 +148,7 @@ export const InputGroupBase = forwardRef<InputGroupForwardRef, InputGroupProps>(
         registerSuffix: () => setHasSuffix(true),
         unregisterSuffix: () => setHasSuffix(false),
       }),
-      [inputId, hasPrefix, hasSuffix, disabled, label]
+      [inputId, hasPrefix, hasSuffix, disabled, invalid, label]
     );
 
     const groupClassName = cn(
@@ -144,6 +158,7 @@ export const InputGroupBase = forwardRef<InputGroupForwardRef, InputGroupProps>(
         [styles['tedi-input-group--has-prefix']]: hasPrefix,
         [styles['tedi-input-group--has-suffix']]: hasSuffix,
         [styles['tedi-input-group--disabled']]: disabled,
+        [styles['tedi-input-group--invalid']]: invalid,
       },
       className
     );
@@ -164,13 +179,13 @@ export const InputGroupBase = forwardRef<InputGroupForwardRef, InputGroupProps>(
 
     return (
       <InputGroupContext.Provider value={ctxValue}>
-        {label && <FormLabel {...labelProps} label={label} id={inputId} />}
-
         <div ref={rootRef} className={groupClassName} data-name="tedi-input-group" aria-disabled={disabled}>
-          {children}
-        </div>
+          {label && <FormLabel {...labelProps} label={label} id={inputId} />}
 
-        {renderFeedback()}
+          <div className={styles['tedi-input-group__row']}>{children}</div>
+
+          {renderFeedback()}
+        </div>
       </InputGroupContext.Provider>
     );
   }

--- a/src/tedi/components/misc/empty-state/empty-state.stories.tsx
+++ b/src/tedi/components/misc/empty-state/empty-state.stories.tsx
@@ -139,3 +139,10 @@ export const CustomIcon: Story = {
     icon: { name: 'shopping_cart_off' },
   },
 };
+
+export const DifferentIconColor: Story = {
+  args: {
+    children: 'You have no data to display',
+    icon: { name: 'spa', color: 'tertiary' },
+  },
+};

--- a/src/tedi/components/misc/empty-state/empty-state.stories.tsx
+++ b/src/tedi/components/misc/empty-state/empty-state.stories.tsx
@@ -18,7 +18,6 @@ const meta: Meta<typeof EmptyState> = {
   component: EmptyState,
   title: 'TEDI-Ready/Components/Helpers/EmptyState',
   argTypes: {
-    icon: { control: false },
     heading: { control: false },
     actions: { control: false },
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * Placeholder component is now deprecated; migrate to EmptyState.

* **New Features**
  * InputGroup gains an explicit invalid prop and improved feedback/error propagation.

* **Bug Fixes**
  * Inputs expose validation state for accessibility (aria-invalid).
  * Prefix and suffix addons reflect the input group's disabled state.

* **Documentation**
  * Updated stories for InputGroup states and a new EmptyState icon-color example.

* **Tests**
  * Added tests for validation propagation and disabled-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->