### PR TITLE
feat(select): ability to wrap tags in smaller inputs #685

### DIFF
--- a/src/tedi/components/form/select/components/select-multi-value.tsx
+++ b/src/tedi/components/form/select/components/select-multi-value.tsx
@@ -1,11 +1,13 @@
+import cn from 'classnames';
 import { MultiValueProps } from 'react-select';
 
-import { Tag } from '../../../tags/tag/tag';
+import { Tag, TagEllipsis } from '../../../tags/tag/tag';
 import { ISelectOption } from '../select';
+import styles from '../select.module.scss';
 import { isGroupSentinel, SELECT_ALL_VALUE } from './select-bulk-helpers';
 import { useSelectTagsContext } from './select-tags-context';
 
-type MultiValueType = MultiValueProps<ISelectOption> & { isTagRemovable?: boolean };
+type MultiValueType = MultiValueProps<ISelectOption> & { isTagRemovable?: boolean; tagsEllipsis?: TagEllipsis };
 
 type RemoveProps = MultiValueProps<ISelectOption>['removeProps'];
 
@@ -40,6 +42,7 @@ export const createMultiValueCloseHandler =
 
 export const SelectMultiValue = ({
   isTagRemovable,
+  tagsEllipsis = false,
   children,
   removeProps,
   ...props
@@ -72,9 +75,14 @@ export const SelectMultiValue = ({
   if (isHidden) return null;
 
   return (
-    <div onMouseDown={(event) => event.stopPropagation()} data-tedi-tag-index={index}>
+    <div
+      onMouseDown={(event) => event.stopPropagation()}
+      data-tedi-tag-index={index}
+      className={cn({ [styles['tedi-select__multi-value--ellipsis']]: tagsEllipsis !== false })}
+    >
       <Tag
         color="primary"
+        ellipsis={tagsEllipsis}
         onClose={isTagRemovable ? handleCloseClick : undefined}
         closeButtonProps={
           isTagRemovable

--- a/src/tedi/components/form/select/select.module.scss
+++ b/src/tedi/components/form/select/select.module.scss
@@ -206,6 +206,11 @@ div.tedi-select__multi-value-item {
   align-items: baseline;
 }
 
+.tedi-select__multi-value--ellipsis {
+  min-width: 0;
+  max-width: 100%;
+}
+
 .tedi-select .tedi-select__group {
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;

--- a/src/tedi/components/form/select/select.spec.tsx
+++ b/src/tedi/components/form/select/select.spec.tsx
@@ -303,6 +303,17 @@ describe('Select component', () => {
     expect(container.querySelectorAll('[data-name="ellipsis"]')).toHaveLength(2);
   });
 
+  it('marks the tag wrapper as shrinkable for ellipsis and handles mousedown', () => {
+    const { container } = render(
+      <Select {...defaultProps} multiple value={[basicOptions[0], basicOptions[1]]} tagsEllipsis="end" />
+    );
+    const wrapper = container.querySelector('[data-tedi-tag-index]');
+    expect(wrapper).toHaveClass('tedi-select__multi-value--ellipsis');
+
+    fireEvent.mouseDown(wrapper!);
+    expect(wrapper).toBeInTheDocument();
+  });
+
   it('renders tag closing button', () => {
     const { container } = render(
       <Select {...defaultProps} multiple value={[basicOptions[0], basicOptions[1]]} isTagRemovable />

--- a/src/tedi/components/form/select/select.spec.tsx
+++ b/src/tedi/components/form/select/select.spec.tsx
@@ -289,6 +289,20 @@ describe('Select component', () => {
     expect(tags.length).toBe(2);
   });
 
+  it('does not ellipse tags by default', () => {
+    const { container } = render(<Select {...defaultProps} multiple value={[basicOptions[0], basicOptions[1]]} />);
+    expect(container.querySelectorAll('.tedi-tag--ellipsis')).toHaveLength(0);
+    expect(container.querySelectorAll('[data-name="ellipsis"]')).toHaveLength(0);
+  });
+
+  it('forwards tagsEllipsis to each selected tag', () => {
+    const { container } = render(
+      <Select {...defaultProps} multiple value={[basicOptions[0], basicOptions[1]]} tagsEllipsis="end" />
+    );
+    expect(container.querySelectorAll('.tedi-tag--ellipsis')).toHaveLength(2);
+    expect(container.querySelectorAll('[data-name="ellipsis"]')).toHaveLength(2);
+  });
+
   it('renders tag closing button', () => {
     const { container } = render(
       <Select {...defaultProps} multiple value={[basicOptions[0], basicOptions[1]]} isTagRemovable />

--- a/src/tedi/components/form/select/select.stories.tsx
+++ b/src/tedi/components/form/select/select.stories.tsx
@@ -355,6 +355,49 @@ export const ValueType: Story = {
   ),
 };
 
+/**
+ * Set `tagsEllipsis` to truncate selected-tag labels when the field is width-constrained;
+ * the full label is shown in a popover on hover/focus. `end` truncates the tail, `start` the
+ * front (keeping the most significant part — e.g. a date or ID — visible). `false` (default)
+ * lets long labels wrap instead.
+ */
+export const EllipsisTags: Story = {
+  render: () => {
+    const longOptions: ISelectOption[] = [
+      { value: 'a', label: 'A fairly long option label that does not fit' },
+      { value: 'b', label: 'Another rather long option label' },
+      { value: 'c', label: '2026-06-25 quarterly financial report' },
+    ];
+
+    return (
+      <div style={{ maxWidth: '20rem' }}>
+        <VerticalSpacing>
+          <Select
+            id="ellipsis-tags-end"
+            label="Truncate the end"
+            options={longOptions}
+            defaultValue={longOptions}
+            multiple
+            tagsEllipsis="end"
+            isTagRemovable
+            isClearable
+          />
+          <Select
+            id="ellipsis-tags-start"
+            label="Truncate the start"
+            options={longOptions}
+            defaultValue={longOptions}
+            multiple
+            tagsEllipsis="start"
+            isTagRemovable
+            isClearable
+          />
+        </VerticalSpacing>
+      </div>
+    );
+  },
+};
+
 const departmentOptions: ISelectOption[] = [
   'Emergency department',
   'Internal medicine',

--- a/src/tedi/components/form/select/select.stories.tsx
+++ b/src/tedi/components/form/select/select.stories.tsx
@@ -356,10 +356,8 @@ export const ValueType: Story = {
 };
 
 /**
- * Set `tagsEllipsis` to truncate selected-tag labels when the field is width-constrained;
- * the full label is shown in a popover on hover/focus. `end` truncates the tail, `start` the
- * front (keeping the most significant part — e.g. a date or ID — visible). `false` (default)
- * lets long labels wrap instead.
+ * `tagsEllipsis` truncates long tag labels: `end` → `Long label…`, `start` → `…label`. The full
+ * label shows in a popover on hover/focus.
  */
 export const EllipsisTags: Story = {
   render: () => {

--- a/src/tedi/components/form/select/select.tsx
+++ b/src/tedi/components/form/select/select.tsx
@@ -18,6 +18,7 @@ import { FormLabel, FormLabelProps } from '../../../../tedi/components/form/form
 import { useLabels } from '../../../../tedi/providers/label-provider';
 import { UnknownType } from '../../../types/commonTypes';
 import { TextProps } from '../../base/typography/text/text';
+import { TagEllipsis } from '../../tags/tag/tag';
 import { useOptionalInputGroup } from '../input-group/input-group';
 import inputGroupStyles from '../input-group/input-group.module.scss';
 import {
@@ -185,6 +186,14 @@ export interface SelectProps extends Omit<FormLabelProps, 'id' | 'label'> {
    * @default 'stack'
    */
   tagsDirection?: 'stack' | 'row';
+  /**
+   * Truncate each selected tag's label when it is width-constrained, revealing
+   * the full text in a popover on hover/focus. `end` shows a trailing ellipsis
+   * (`Long label…`); `start` a leading one (`…label`). `false` never truncates —
+   * long labels wrap. Forwarded to each tag's `ellipsis` prop.
+   * @default false
+   */
+  tagsEllipsis?: TagEllipsis;
   /**
    * Layout for the dropdown menu.
    * - `"menu"` (default): vertical list of options.
@@ -451,6 +460,7 @@ export const Select = forwardRef<SelectInstance<ISelectOption, boolean, IGrouped
       onBlur,
       inputIsHidden,
       isTagRemovable = false,
+      tagsEllipsis = false,
       backspaceRemovesValue = false,
       optionGroupHeadingText = { modifiers: 'small', color: 'tertiary' },
       cacheOptions = true,
@@ -655,7 +665,7 @@ export const Select = forwardRef<SelectInstance<ISelectOption, boolean, IGrouped
         Option: (props) => SelectOption({ renderOption, multiple, showRadioButtons, ...props }),
         Control: SelectControl,
         Input: SelectInput,
-        MultiValue: (props) => SelectMultiValue({ isTagRemovable, ...props }),
+        MultiValue: (props) => SelectMultiValue({ isTagRemovable, tagsEllipsis, ...props }),
         MultiValueRemove: SelectMultiValueRemove,
         SingleValue: SelectSingleValue,
         Group: SelectGroup,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional ellipsis handling for selected multi-value tags in select controls.
  * Introduced demo examples showing truncation at the start or end of long tag labels.

* **Bug Fixes**
  * Improved multi-select tag overflow behavior so tags render correctly within narrow spaces.
  * Ensured tag close actions work consistently with both mouse and keyboard input.

* **Tests**
  * Added coverage for default no-ellipsis behavior and for ellipsis forwarding when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->