### PR TITLE
feat(info-button): focus ring offset reduced #719

### DIFF
--- a/src/tedi/components/buttons/info-button/info-button.module.scss
+++ b/src/tedi/components/buttons/info-button/info-button.module.scss
@@ -4,6 +4,14 @@
   min-height: var(--button-xs-icon-size);
   vertical-align: bottom;
 
+  // Small icon button: inset the focus ring so it stays within the button's
+  // bounds instead of the base button's +1px outset. The extra `[data-name]`
+  // (already set by the component) matches the base `.tedi-btn--default
+  // .tedi-btn--neutral:focus-visible` specificity so this override wins.
+  &[data-name='info-button']:focus-visible:not(:disabled, [aria-disabled='true']) {
+    outline-offset: calc(-1 * var(--tedi-borders-02));
+  }
+
   &[data-variant='inverted']:hover:not(:disabled) {
     background-color: var(--button-main-neutral-inverted-icon-only-background-hover);
   }

--- a/src/tedi/components/buttons/info-button/info-button.module.scss
+++ b/src/tedi/components/buttons/info-button/info-button.module.scss
@@ -4,10 +4,6 @@
   min-height: var(--button-xs-icon-size);
   vertical-align: bottom;
 
-  // Small icon button: inset the focus ring so it stays within the button's
-  // bounds instead of the base button's +1px outset. The extra `[data-name]`
-  // (already set by the component) matches the base `.tedi-btn--default
-  // .tedi-btn--neutral:focus-visible` specificity so this override wins.
   &[data-name='info-button']:focus-visible:not(:disabled, [aria-disabled='true']) {
     outline-offset: calc(-1 * var(--tedi-borders-02));
   }

--- a/src/tedi/components/overlays/overlay/overlay.module.scss
+++ b/src/tedi/components/overlays/overlay/overlay.module.scss
@@ -11,6 +11,11 @@
     &--text {
       text-decoration: underline dashed var(--general-border-secondary);
       text-underline-offset: 0.5em;
+
+      &:hover {
+        color: var(--link-primary-default);
+        text-decoration-color: var(--general-border-brand);
+      }
     }
 
     &--click {


### PR DESCRIPTION
* feat(tooltip,popover): hover color changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard focus styling for the info button so the focus state is clearer and more consistent.
  * Updated hovered overlay trigger text to use the primary link color and a matching underline color, improving visual feedback on hover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->