### PR TITLE
feat(label-provider): turn default locale to "et", remove decorations from stories #683

### DIFF
--- a/.storybook/storybook-decorator.tsx
+++ b/.storybook/storybook-decorator.tsx
@@ -14,7 +14,7 @@ interface StorybookDecoratorProps {
   locale?: LabelProviderProps['locale'];
 }
 
-const StorybookDecorator = ({ children, locale = 'en', ...rest }: StorybookDecoratorProps) => (
+const StorybookDecorator = ({ children, locale = 'et', ...rest }: StorybookDecoratorProps) => (
   <LabelProvider locale={locale} {...rest}>
     <AccessibilityProvider>{children}</AccessibilityProvider>
   </LabelProvider>

--- a/src/tedi/components/content/accordion/accordion.stories.tsx
+++ b/src/tedi/components/content/accordion/accordion.stories.tsx
@@ -7,7 +7,6 @@ import {
   subcomponentArgTypes,
 } from '../../../../../.storybook/subcomponent-controls';
 import { useBreakpointProps } from '../../../helpers';
-import { LabelProvider } from '../../../providers/label-provider';
 import { Icon } from '../../base/icon/icon';
 import { Heading } from '../../base/typography/heading/heading';
 import { Text } from '../../base/typography/text/text';
@@ -30,13 +29,6 @@ import { AccordionItemHeaderProps } from './accordion-item-header/accordion-item
 export default {
   title: 'TEDI-Ready/Content/Accordion',
   component: Accordion,
-  decorators: [
-    (Story) => (
-      <LabelProvider locale="et">
-        <Story />
-      </LabelProvider>
-    ),
-  ],
   parameters: {
     status: {
       type: [{ name: 'breakpointSupport', url: '?path=/docs/helpers-usebreakpointprops--usebreakpointprops' }],

--- a/src/tedi/components/content/collapse/collapse.stories.tsx
+++ b/src/tedi/components/content/collapse/collapse.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 
-import { LabelProvider } from '../../../providers/label-provider';
 import { Heading } from '../../base/typography/heading/heading';
 import { Text } from '../../base/typography/text/text';
 import { VerticalSpacing } from '../../layout/vertical-spacing';
@@ -24,13 +23,6 @@ const meta: Meta<typeof Collapse> = {
       exclude: ['sm', 'md', 'lg', 'xl', 'xxl'],
     },
   },
-  decorators: [
-    (Story) => (
-      <LabelProvider locale="et">
-        <Story />
-      </LabelProvider>
-    ),
-  ],
   argTypes: {
     title: { control: false },
     children: { control: false },

--- a/src/tedi/components/form/date-field/date-field.stories.tsx
+++ b/src/tedi/components/form/date-field/date-field.stories.tsx
@@ -2,7 +2,6 @@ import { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { DateRange } from 'react-day-picker';
 
-import { LabelProvider } from '../../../providers/label-provider';
 import { Text } from '../../base/typography/text/text';
 import Button from '../../buttons/button/button';
 import { Col, Row } from '../../layout/grid';
@@ -18,15 +17,6 @@ import { DateField, DateFieldProps } from './date-field';
 export default {
   title: 'Tedi-Ready/Components/Form/DateField',
   component: DateField,
-  // The examples use Estonian content, so surface the Estonian modal labels (title, Cancel/Confirm,
-  // month-nav aria-labels) by overriding the Storybook default `LabelProvider locale="en"`.
-  decorators: [
-    (Story) => (
-      <LabelProvider locale="et">
-        <Story />
-      </LabelProvider>
-    ),
-  ],
   parameters: {
     status: {
       type: [{ name: 'breakpointSupport', url: '?path=/docs/helpers-usebreakpointprops--usebreakpointprops' }],

--- a/src/tedi/components/form/file-dropzone/file-dropzone.stories.tsx
+++ b/src/tedi/components/form/file-dropzone/file-dropzone.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
 
-import { LabelProvider } from '../../../providers/label-provider';
 import { Col, Row } from '../../layout/grid';
 import { FileDropzone, FileDropzoneProps } from './file-dropzone';
 
@@ -15,13 +14,6 @@ const meta: Meta<typeof FileDropzone> = {
   args: {
     name: 'file-dropzone',
   },
-  decorators: [
-    (Story) => (
-      <LabelProvider locale="et">
-        <Story />
-      </LabelProvider>
-    ),
-  ],
 };
 
 export default meta;

--- a/src/tedi/components/form/file-upload/file-upload.stories.tsx
+++ b/src/tedi/components/form/file-upload/file-upload.stories.tsx
@@ -2,7 +2,6 @@ import { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
 import { FileUploadFile } from '../../../helpers';
-import { LabelProvider } from '../../../providers/label-provider';
 import { Text } from '../../base/typography/text/text';
 import Button from '../../buttons/button/button';
 import { Col, Row } from '../../layout/grid';
@@ -23,13 +22,6 @@ const meta: Meta<typeof FileUpload> = {
       url: 'https://www.figma.com/design/jWiRIXhHRxwVdMSimKX2FF/TEDI-READY-(work-in-progress)?node-id=4536-78765&m=dev',
     },
   },
-  decorators: [
-    (Story) => (
-      <LabelProvider locale="et">
-        <Story />
-      </LabelProvider>
-    ),
-  ],
 };
 
 export default meta;

--- a/src/tedi/components/form/time-field/time-field.stories.tsx
+++ b/src/tedi/components/form/time-field/time-field.stories.tsx
@@ -1,7 +1,6 @@
 import { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
-import { LabelProvider } from '../../../providers/label-provider';
 import { Text } from '../../base/typography/text/text';
 import { Col, Row } from '../../layout/grid';
 import { VerticalSpacing } from '../../layout/vertical-spacing';
@@ -337,11 +336,7 @@ export const ManualTyping: StoryFn<TimeFieldProps> = (args) => {
  * Confirm — Cancel / Escape / backdrop dismiss discards it.
  */
 export const ModalPicker: Story = {
-  render: (args) => (
-    <LabelProvider locale="et">
-      <Template {...args} />
-    </LabelProvider>
-  ),
+  render: (args) => <Template {...args} />,
   args: {
     id: 'time-modal',
     label: 'Aeg',
@@ -357,11 +352,7 @@ export const ModalPicker: Story = {
  * canvas or pick a mobile preset to see the modal kick in.
  */
 export const ResponsiveModalPicker: Story = {
-  render: (args) => (
-    <LabelProvider locale="et">
-      <Template {...args} />
-    </LabelProvider>
-  ),
+  render: (args) => <Template {...args} />,
   args: {
     id: 'time-modal-responsive',
     label: 'Aeg',

--- a/src/tedi/components/navigation/table-of-contents/table-of-contents.stories.tsx
+++ b/src/tedi/components/navigation/table-of-contents/table-of-contents.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { type CSSProperties, useEffect, useRef, useState } from 'react';
 
 import { isBreakpointBelow, useBreakpoint } from '../../../helpers';
-import { LabelProvider } from '../../../providers/label-provider';
 import { Heading } from '../../base/typography/heading/heading';
 import { Text } from '../../base/typography/text/text';
 import { Col, Row } from '../../layout/grid';
@@ -32,11 +31,9 @@ const meta: Meta<typeof TableOfContents> = {
   },
   decorators: [
     (Story, context) => (
-      <LabelProvider locale="et">
-        <div style={{ maxWidth: context.parameters.fullWidth ? undefined : 320 }}>
-          <Story />
-        </div>
-      </LabelProvider>
+      <div style={{ maxWidth: context.parameters.fullWidth ? undefined : 320 }}>
+        <Story />
+      </div>
     ),
   ],
 };

--- a/src/tedi/providers/label-provider/label-provider.tsx
+++ b/src/tedi/providers/label-provider/label-provider.tsx
@@ -63,13 +63,13 @@ export const LabelContext = React.createContext<ILabelContext>({
       console.error('LabelProvider missing! Application must be wrapped with <LabelProvider>');
     }
   },
-  locale: 'en',
+  locale: 'et',
 });
 
 export interface LabelProviderProps<TRecord extends TediLabelEntryRecord<TRecord> = Record<string, never>> {
   /**
    * Global labels that are use in components. If omitted then default labels are used based on `locale` prop.
-   * If both props are omitted then English translations are used by default
+   * If both props are omitted then Estonian translations are used by default
    */
   labels?: TRecord | TediLabelValuesRecord;
   /**
@@ -77,7 +77,7 @@ export interface LabelProviderProps<TRecord extends TediLabelEntryRecord<TRecord
    * et - Estonian<br />
    * en - English<br />
    * ru - Russian
-   * @default en
+   * @default et
    */
   locale?: TediLanguage;
   /**
@@ -89,7 +89,7 @@ export interface LabelProviderProps<TRecord extends TediLabelEntryRecord<TRecord
 export const LabelProvider = <TRecord extends TediLabelEntryRecord<TRecord>>(
   props: LabelProviderProps<TRecord>
 ): JSX.Element => {
-  const { labels = {}, children, locale = 'en' } = props;
+  const { labels = {}, children, locale = 'et' } = props;
 
   const [currentLocale, setCurrentLocale] = React.useState<TediLanguage>(locale);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default labels and preview content now use Estonian by default in the component showcase.
* **Bug Fixes**
  * Simplified several component previews so they render consistently without extra locale setup.
  * Improved preview behavior for date, time, file upload, file dropzone, accordion, collapse, and navigation examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->