### PR TITLE
feat/727: new split pane component (map components)

### DIFF
--- a/src/community/components/map-components/split-pane/split-pane.module.scss
+++ b/src/community/components/map-components/split-pane/split-pane.module.scss
@@ -1,0 +1,103 @@
+.tedi-split-pane {
+  display: flex;
+  width: 100%;
+  height: 100%;
+
+  &--horizontal {
+    flex-direction: row;
+  }
+
+  &--vertical {
+    flex-direction: column;
+  }
+
+  &__pane {
+    position: relative;
+    flex-basis: 0;
+    overflow: hidden;
+  }
+
+  &__divider {
+    position: relative;
+    z-index: 1;
+    flex: 0 0 var(--drag-indicator-vertical-width);
+    touch-action: none;
+    background-color: var(--drag-indicator-accent);
+
+    &:focus-visible {
+      outline: var(--tedi-dimensions-03) solid var(--general-border-accent);
+      outline-offset: var(--tedi-dimensions-03);
+    }
+
+    .tedi-split-pane--horizontal & {
+      cursor: col-resize;
+    }
+
+    .tedi-split-pane--vertical & {
+      cursor: row-resize;
+    }
+  }
+
+  &__handle {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    z-index: 12;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--button-sm-icon-size);
+    height: var(--button-sm-icon-size);
+    color: var(--button-floating-secondary-text-default);
+    background-color: var(--button-floating-secondary-background-default);
+    border-radius: var(--button-radius-default);
+    box-shadow: 0 4px 10px 0 var(--tedi-alpha-14);
+    transform: translate(-50%, -50%);
+
+    .tedi-split-pane--vertical & > span {
+      transform: rotate(90deg);
+    }
+  }
+
+  &__close {
+    position: absolute;
+    z-index: 13;
+
+    .tedi-split-pane--horizontal & {
+      top: 10%;
+      left: 50%;
+      transform: translateX(-50%);
+    }
+
+    .tedi-split-pane--vertical & {
+      top: 50%;
+      left: 10%;
+      transform: translateY(-50%);
+    }
+  }
+
+  &__ring {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    box-sizing: border-box;
+    pointer-events: none;
+    border: var(--tedi-dimensions-03) solid var(--drag-indicator-accent);
+
+    &--omit-top {
+      border-top-width: 0;
+    }
+
+    &--omit-right {
+      border-right-width: 0;
+    }
+
+    &--omit-bottom {
+      border-bottom-width: 0;
+    }
+
+    &--omit-left {
+      border-left-width: 0;
+    }
+  }
+}

--- a/src/community/components/map-components/split-pane/split-pane.module.scss
+++ b/src/community/components/map-components/split-pane/split-pane.module.scss
@@ -54,14 +54,15 @@
     box-shadow: 0 4px 10px 0 var(--tedi-alpha-14);
     transform: translate(-50%, -50%);
 
-    .tedi-split-pane--vertical & > span {
-      transform: rotate(90deg);
+    > span {
+      color: inherit;
     }
   }
 
   &__close {
     position: absolute;
     z-index: 13;
+    width: max-content;
 
     .tedi-split-pane--horizontal & {
       top: 10%;

--- a/src/community/components/map-components/split-pane/split-pane.spec.tsx
+++ b/src/community/components/map-components/split-pane/split-pane.spec.tsx
@@ -199,6 +199,23 @@ describe('SplitPane', () => {
       expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('80');
     });
 
+    it('honours custom minRatio/maxRatio bounds', () => {
+      render(
+        <SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" minRatio={30} maxRatio={70} />
+      );
+      mockContainerRect();
+
+      const divider = screen.getByRole('separator');
+      expect(divider).toHaveAttribute('aria-valuemin', '30');
+      expect(divider).toHaveAttribute('aria-valuemax', '70');
+
+      fireEvent.mouseDown(divider, { clientX: 500, clientY: 250 });
+      fireEvent.mouseMove(document, { clientX: 950, clientY: 250 });
+      fireEvent.mouseUp(document);
+
+      expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('70');
+    });
+
     it('reports the final ratio via onRatioChange on drag end', () => {
       const onRatioChange = jest.fn();
       render(

--- a/src/community/components/map-components/split-pane/split-pane.spec.tsx
+++ b/src/community/components/map-components/split-pane/split-pane.spec.tsx
@@ -84,14 +84,14 @@ describe('SplitPane', () => {
       const onClose = jest.fn();
       render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" onClose={onClose} />);
 
-      fireEvent.click(screen.getByTestId('split-pane-close'));
+      fireEvent.click(screen.getByRole('button'));
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
     it('does not render a close button without onClose', () => {
       render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" />);
 
-      expect(screen.queryByTestId('split-pane-close')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
     });
   });
 
@@ -113,9 +113,20 @@ describe('SplitPane', () => {
       render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" />);
       mockContainerRect();
 
-      fireEvent.mouseDown(screen.getByTestId('split-pane-divider'), { clientX: 500, clientY: 250 });
+      fireEvent.mouseDown(screen.getByRole('separator'), { clientX: 500, clientY: 250 });
       fireEvent.mouseMove(document, { clientX: 700, clientY: 250 });
       fireEvent.mouseUp(document);
+
+      expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('70');
+    });
+
+    it('updates pane sizes on divider touch drag', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" />);
+      mockContainerRect();
+
+      fireEvent.touchStart(screen.getByRole('separator'), { touches: [{ clientX: 500, clientY: 250 }] });
+      fireEvent.touchMove(document, { touches: [{ clientX: 700, clientY: 250 }] });
+      fireEvent.touchEnd(document);
 
       expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('70');
     });
@@ -124,7 +135,7 @@ describe('SplitPane', () => {
       render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" />);
       mockContainerRect();
 
-      fireEvent.mouseDown(screen.getByTestId('split-pane-divider'), { clientX: 500, clientY: 250 });
+      fireEvent.mouseDown(screen.getByRole('separator'), { clientX: 500, clientY: 250 });
       fireEvent.mouseMove(document, { clientX: 50, clientY: 250 });
       fireEvent.mouseUp(document);
 
@@ -135,7 +146,7 @@ describe('SplitPane', () => {
       render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" />);
       mockContainerRect();
 
-      fireEvent.mouseDown(screen.getByTestId('split-pane-divider'), { clientX: 500, clientY: 250 });
+      fireEvent.mouseDown(screen.getByRole('separator'), { clientX: 500, clientY: 250 });
       fireEvent.mouseMove(document, { clientX: 950, clientY: 250 });
       fireEvent.mouseUp(document);
 
@@ -146,7 +157,7 @@ describe('SplitPane', () => {
       render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="vertical" />);
       mockContainerRect({ width: 500, height: 1000, right: 500, bottom: 1000 });
 
-      fireEvent.mouseDown(screen.getByTestId('split-pane-divider'), { clientX: 250, clientY: 500 });
+      fireEvent.mouseDown(screen.getByRole('separator'), { clientX: 250, clientY: 500 });
       fireEvent.mouseMove(document, { clientX: 250, clientY: 600 });
       fireEvent.mouseUp(document);
 
@@ -167,7 +178,7 @@ describe('SplitPane', () => {
       render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" onClose={onClose} />);
       mockContainerRect();
 
-      fireEvent.mouseDown(screen.getByTestId('split-pane-close'), { clientX: 500, clientY: 250 });
+      fireEvent.mouseDown(screen.getByRole('button'), { clientX: 500, clientY: 250 });
       fireEvent.mouseMove(document, { clientX: 800, clientY: 250 });
       fireEvent.mouseUp(document);
 
@@ -195,7 +206,7 @@ describe('SplitPane', () => {
       );
       mockContainerRect();
 
-      fireEvent.mouseDown(screen.getByTestId('split-pane-divider'), { clientX: 500, clientY: 250 });
+      fireEvent.mouseDown(screen.getByRole('separator'), { clientX: 500, clientY: 250 });
       fireEvent.mouseMove(document, { clientX: 700, clientY: 250 });
       fireEvent.mouseUp(document);
 

--- a/src/community/components/map-components/split-pane/split-pane.spec.tsx
+++ b/src/community/components/map-components/split-pane/split-pane.spec.tsx
@@ -1,0 +1,259 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+
+import '@testing-library/jest-dom';
+
+// The `src/tedi` barrel transitively imports react-sticky-box (ESM-only), which Jest does not transform.
+jest.mock('react-sticky-box', () => ({ __esModule: true, default: () => null }));
+
+import { LabelProvider } from '../../../../tedi/providers/label-provider/label-provider';
+import { SplitPane } from './split-pane';
+
+const RECT = {
+  left: 0,
+  top: 0,
+  width: 1000,
+  height: 500,
+  right: 1000,
+  bottom: 500,
+  x: 0,
+  y: 0,
+  toJSON: () => ({}),
+} as DOMRect;
+
+const mockContainerRect = (rect: Partial<DOMRect> = {}): void => {
+  jest.spyOn(screen.getByTestId('split-pane'), 'getBoundingClientRect').mockReturnValue({ ...RECT, ...rect });
+};
+
+describe('SplitPane', () => {
+  describe('rendering', () => {
+    it('renders first and second pane content', () => {
+      render(<SplitPane first={<span>First</span>} second={<span>Second</span>} direction="horizontal" />);
+
+      expect(screen.getByText('First')).toBeInTheDocument();
+      expect(screen.getByText('Second')).toBeInTheDocument();
+    });
+
+    it('exposes the divider as a separator with orientation for horizontal', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" />);
+
+      const divider = screen.getByRole('separator');
+      expect(divider).toHaveAttribute('aria-orientation', 'vertical');
+      expect(divider).toHaveAttribute('aria-valuenow', '50');
+      expect(divider).toHaveAttribute('tabindex', '0');
+    });
+
+    it('exposes horizontal orientation for a vertical split', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="vertical" />);
+
+      expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', 'horizontal');
+    });
+
+    it('renders the drag grip as a non-interactive visual affordance', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" />);
+
+      expect(screen.getByTestId('split-pane-handle')).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  describe('highlighted side', () => {
+    it('rings the first pane and omits the divider-facing edge (horizontal)', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" highlightedSide="first" />);
+
+      const ring = within(screen.getByTestId('split-pane-first')).getByTestId('active-pane-ring');
+      expect(ring).toHaveClass('tedi-split-pane__ring--omit-right');
+      expect(within(screen.getByTestId('split-pane-second')).queryByTestId('active-pane-ring')).not.toBeInTheDocument();
+    });
+
+    it('rings the second pane and omits its divider-facing edge (horizontal)', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" highlightedSide="second" />);
+
+      const ring = within(screen.getByTestId('split-pane-second')).getByTestId('active-pane-ring');
+      expect(ring).toHaveClass('tedi-split-pane__ring--omit-left');
+    });
+
+    it('omits the bottom edge for the first pane in a vertical split', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="vertical" highlightedSide="first" />);
+
+      const ring = within(screen.getByTestId('split-pane-first')).getByTestId('active-pane-ring');
+      expect(ring).toHaveClass('tedi-split-pane__ring--omit-bottom');
+    });
+  });
+
+  describe('close button', () => {
+    it('renders a close button and calls onClose on click when onClose is provided', () => {
+      const onClose = jest.fn();
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" onClose={onClose} />);
+
+      fireEvent.click(screen.getByTestId('split-pane-close'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render a close button without onClose', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" />);
+
+      expect(screen.queryByTestId('split-pane-close')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('localized accessible names', () => {
+    it('resolves labels through LabelProvider (Estonian by default)', () => {
+      render(
+        <LabelProvider>
+          <SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" onClose={jest.fn()} />
+        </LabelProvider>
+      );
+
+      expect(screen.getByRole('separator')).toHaveAccessibleName('Muuda paanide suurust');
+      expect(screen.getByRole('button', { name: 'Sulge' })).toBeInTheDocument();
+    });
+  });
+
+  describe('pointer interactions', () => {
+    it('updates pane sizes on divider drag', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" />);
+      mockContainerRect();
+
+      fireEvent.mouseDown(screen.getByTestId('split-pane-divider'), { clientX: 500, clientY: 250 });
+      fireEvent.mouseMove(document, { clientX: 700, clientY: 250 });
+      fireEvent.mouseUp(document);
+
+      expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('70');
+    });
+
+    it('clamps the ratio to a minimum of 20%', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" />);
+      mockContainerRect();
+
+      fireEvent.mouseDown(screen.getByTestId('split-pane-divider'), { clientX: 500, clientY: 250 });
+      fireEvent.mouseMove(document, { clientX: 50, clientY: 250 });
+      fireEvent.mouseUp(document);
+
+      expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('20');
+    });
+
+    it('clamps the ratio to a maximum of 80%', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" />);
+      mockContainerRect();
+
+      fireEvent.mouseDown(screen.getByTestId('split-pane-divider'), { clientX: 500, clientY: 250 });
+      fireEvent.mouseMove(document, { clientX: 950, clientY: 250 });
+      fireEvent.mouseUp(document);
+
+      expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('80');
+    });
+
+    it('uses the vertical axis for a vertical split', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="vertical" />);
+      mockContainerRect({ width: 500, height: 1000, right: 500, bottom: 1000 });
+
+      fireEvent.mouseDown(screen.getByTestId('split-pane-divider'), { clientX: 250, clientY: 500 });
+      fireEvent.mouseMove(document, { clientX: 250, clientY: 600 });
+      fireEvent.mouseUp(document);
+
+      expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('60');
+    });
+
+    it('does not update the ratio without a preceding mousedown', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" />);
+      mockContainerRect();
+
+      fireEvent.mouseMove(document, { clientX: 700, clientY: 250 });
+
+      expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('50');
+    });
+
+    it('does not start a drag when the close button is pressed', () => {
+      const onClose = jest.fn();
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" onClose={onClose} />);
+      mockContainerRect();
+
+      fireEvent.mouseDown(screen.getByTestId('split-pane-close'), { clientX: 500, clientY: 250 });
+      fireEvent.mouseMove(document, { clientX: 800, clientY: 250 });
+      fireEvent.mouseUp(document);
+
+      expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('50');
+    });
+  });
+
+  describe('controlled ratio', () => {
+    it('seeds the pane size from initialRatio', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" initialRatio={70} />);
+
+      expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('70');
+    });
+
+    it('clamps an out-of-range initialRatio', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" initialRatio={95} />);
+
+      expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('80');
+    });
+
+    it('reports the final ratio via onRatioChange on drag end', () => {
+      const onRatioChange = jest.fn();
+      render(
+        <SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" onRatioChange={onRatioChange} />
+      );
+      mockContainerRect();
+
+      fireEvent.mouseDown(screen.getByTestId('split-pane-divider'), { clientX: 500, clientY: 250 });
+      fireEvent.mouseMove(document, { clientX: 700, clientY: 250 });
+      fireEvent.mouseUp(document);
+
+      expect(onRatioChange).toHaveBeenCalledTimes(1);
+      expect(onRatioChange).toHaveBeenCalledWith(70);
+    });
+  });
+
+  describe('keyboard interactions', () => {
+    it('increases the ratio with the forward arrow (horizontal)', () => {
+      const onRatioChange = jest.fn();
+      render(
+        <SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" onRatioChange={onRatioChange} />
+      );
+
+      fireEvent.keyDown(screen.getByRole('separator'), { key: 'ArrowRight' });
+
+      expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('52');
+      expect(onRatioChange).toHaveBeenCalledWith(52);
+    });
+
+    it('decreases the ratio with the backward arrow (horizontal)', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" />);
+
+      fireEvent.keyDown(screen.getByRole('separator'), { key: 'ArrowLeft' });
+
+      expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('48');
+    });
+
+    it('uses the vertical arrows for a vertical split', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="vertical" />);
+
+      fireEvent.keyDown(screen.getByRole('separator'), { key: 'ArrowDown' });
+
+      expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('52');
+    });
+
+    it('jumps to the bounds with Home and End', () => {
+      render(<SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" />);
+      const divider = screen.getByRole('separator');
+
+      fireEvent.keyDown(divider, { key: 'Home' });
+      expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('20');
+
+      fireEvent.keyDown(divider, { key: 'End' });
+      expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('80');
+    });
+
+    it('ignores unrelated keys', () => {
+      const onRatioChange = jest.fn();
+      render(
+        <SplitPane first={<div>A</div>} second={<div>B</div>} direction="horizontal" onRatioChange={onRatioChange} />
+      );
+
+      fireEvent.keyDown(screen.getByRole('separator'), { key: 'Enter' });
+
+      expect(screen.getByTestId('split-pane-first').style.flexGrow).toBe('50');
+      expect(onRatioChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/community/components/map-components/split-pane/split-pane.stories.tsx
+++ b/src/community/components/map-components/split-pane/split-pane.stories.tsx
@@ -4,12 +4,20 @@ import { JSX } from 'react';
 import SplitPane, { SplitPaneProps } from './split-pane';
 
 /**
+ * <a href="https://www.figma.com/design/3DIVbgDcC0R4qgqWhZMfvw/TEDI-Map-Components-1.1.1?node-id=347-72394&t=UN6CIlRIfpadwwCZ-0" target="_BLANK">Figma ↗</a>
+ *
  * `SplitPane` renders two panes separated by a draggable divider. Dragging the divider (mouse, touch,
  * or keyboard) reallocates the size ratio between the panes, clamped to 20–80%.
  */
 const meta: Meta<typeof SplitPane> = {
   component: SplitPane,
   title: 'Community/Map components/SplitPane',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/3DIVbgDcC0R4qgqWhZMfvw/TEDI-Map-Components-1.1.1?node-id=347-72394&t=UN6CIlRIfpadwwCZ-0',
+    },
+  },
 };
 
 export default meta;

--- a/src/community/components/map-components/split-pane/split-pane.stories.tsx
+++ b/src/community/components/map-components/split-pane/split-pane.stories.tsx
@@ -33,7 +33,7 @@ const Template = (args: SplitPaneProps): JSX.Element => (
   </div>
 );
 
-export const Horizontal: Story = {
+export const Default: Story = {
   render: Template,
   args: {
     direction: 'horizontal',
@@ -44,20 +44,20 @@ export const Horizontal: Story = {
 
 export const Vertical: Story = {
   render: Template,
-  args: { ...Horizontal.args, direction: 'vertical' },
+  args: { ...Default.args, direction: 'vertical' },
 };
 
 export const WithHighlightedSide: Story = {
   render: Template,
-  args: { ...Horizontal.args, highlightedSide: 'first' },
+  args: { ...Default.args, highlightedSide: 'first' },
 };
 
 export const WithCloseButton: Story = {
   render: Template,
-  args: { ...Horizontal.args, onClose: () => undefined },
+  args: { ...Default.args, onClose: () => undefined },
 };
 
 export const CustomInitialRatio: Story = {
   render: Template,
-  args: { ...Horizontal.args, initialRatio: 70 },
+  args: { ...Default.args, initialRatio: 70 },
 };

--- a/src/community/components/map-components/split-pane/split-pane.stories.tsx
+++ b/src/community/components/map-components/split-pane/split-pane.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { JSX } from 'react';
+
+import SplitPane, { SplitPaneProps } from './split-pane';
+
+/**
+ * `SplitPane` renders two panes separated by a draggable divider. Dragging the divider (mouse, touch,
+ * or keyboard) reallocates the size ratio between the panes, clamped to 20–80%.
+ */
+const meta: Meta<typeof SplitPane> = {
+  component: SplitPane,
+  title: 'Community/Map components/SplitPane',
+};
+
+export default meta;
+type Story = StoryObj<typeof SplitPane>;
+
+const demoPane = (label: string, background: string): JSX.Element => (
+  <div style={{ display: 'grid', width: '100%', height: '100%', placeItems: 'center', background }}>{label}</div>
+);
+
+const Template = (args: SplitPaneProps): JSX.Element => (
+  <div style={{ width: '800px', height: '400px' }}>
+    <SplitPane {...args} />
+  </div>
+);
+
+export const Horizontal: Story = {
+  render: Template,
+  args: {
+    direction: 'horizontal',
+    first: demoPane('First', 'var(--tedi-primary-100)'),
+    second: demoPane('Second', 'var(--tedi-primary-200)'),
+  },
+};
+
+export const Vertical: Story = {
+  render: Template,
+  args: { ...Horizontal.args, direction: 'vertical' },
+};
+
+export const WithHighlightedSide: Story = {
+  render: Template,
+  args: { ...Horizontal.args, highlightedSide: 'first' },
+};
+
+export const WithCloseButton: Story = {
+  render: Template,
+  args: { ...Horizontal.args, onClose: () => undefined },
+};
+
+export const CustomInitialRatio: Story = {
+  render: Template,
+  args: { ...Horizontal.args, initialRatio: 70 },
+};

--- a/src/community/components/map-components/split-pane/split-pane.stories.tsx
+++ b/src/community/components/map-components/split-pane/split-pane.stories.tsx
@@ -28,7 +28,7 @@ const demoPane = (label: string, background: string): JSX.Element => (
 );
 
 const Template = (args: SplitPaneProps): JSX.Element => (
-  <div style={{ width: '800px', height: '400px' }}>
+  <div style={{ width: '100%', maxWidth: '800px', height: '400px' }}>
     <SplitPane {...args} />
   </div>
 );

--- a/src/community/components/map-components/split-pane/split-pane.tsx
+++ b/src/community/components/map-components/split-pane/split-pane.tsx
@@ -24,7 +24,7 @@ export interface SplitPaneProps {
    * @default 50
    */
   initialRatio?: number;
-  /** Called with the final ratio (%) when a drag or keyboard adjustment ends. */
+  /** Called with the final ratio (%) when a drag or keyboard adjustment event ends. */
   onRatioChange?: (ratio: number) => void;
 }
 

--- a/src/community/components/map-components/split-pane/split-pane.tsx
+++ b/src/community/components/map-components/split-pane/split-pane.tsx
@@ -1,0 +1,205 @@
+import cn from 'classnames';
+import React, { JSX, ReactNode, useRef, useState } from 'react';
+
+import { Button, Icon, useLabels } from '../../../../tedi';
+import styles from './split-pane.module.scss';
+
+type PaneSide = 'first' | 'second';
+type PaneEdge = 'top' | 'right' | 'bottom' | 'left';
+type SplitPaneDirection = 'horizontal' | 'vertical';
+
+export interface SplitPaneProps {
+  /** Content of the first (left in horizontal, top in vertical) pane. */
+  first: ReactNode;
+  /** Content of the second (right in horizontal, bottom in vertical) pane. */
+  second: ReactNode;
+  /** Layout axis: `horizontal` places panes side by side, `vertical` stacks them. */
+  direction: SplitPaneDirection;
+  /** Draws an accent ring around the given pane to mark it as active. */
+  highlightedSide?: PaneSide;
+  /** When provided, renders a close button on the divider. */
+  onClose?: () => void;
+  /**
+   * Initial size of the first pane as a percentage of the container, clamped to 20–80.
+   * @default 50
+   */
+  initialRatio?: number;
+  /** Called with the final ratio (%) when a drag or keyboard adjustment ends. */
+  onRatioChange?: (ratio: number) => void;
+}
+
+const MIN_RATIO = 20;
+const MAX_RATIO = 80;
+const KEYBOARD_STEP = 2;
+
+const clampRatio = (value: number): number => Math.max(MIN_RATIO, Math.min(MAX_RATIO, value));
+
+const getOmittedEdge = (isHorizontal: boolean, side: PaneSide): PaneEdge => {
+  if (isHorizontal) {
+    return side === 'first' ? 'right' : 'left';
+  }
+
+  return side === 'first' ? 'bottom' : 'top';
+};
+
+interface SplitPaneRingProps {
+  direction: SplitPaneDirection;
+  side: PaneSide;
+}
+
+const SplitPaneRing = ({ direction, side }: SplitPaneRingProps): JSX.Element => {
+  const omittedEdge = getOmittedEdge(direction === 'horizontal', side);
+
+  return (
+    <div
+      data-testid="active-pane-ring"
+      aria-hidden
+      className={cn(styles['tedi-split-pane__ring'], styles[`tedi-split-pane__ring--omit-${omittedEdge}`])}
+    />
+  );
+};
+
+export const SplitPane = (props: SplitPaneProps): JSX.Element => {
+  const { first, second, direction, highlightedSide, onClose, initialRatio = 50, onRatioChange } = props;
+  const { getLabel } = useLabels();
+
+  const [ratio, setRatio] = useState<number>(() => clampRatio(initialRatio));
+  const ratioRef = useRef<number>(ratio);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const isHorizontal = direction === 'horizontal';
+
+  const applyRatio = (next: number): void => {
+    const clamped = clampRatio(next);
+    ratioRef.current = clamped;
+    setRatio(clamped);
+  };
+
+  const updateRatioFromPoint = (x: number, y: number): void => {
+    if (!containerRef.current) {
+      return;
+    }
+
+    const rect = containerRef.current.getBoundingClientRect();
+    const raw = isHorizontal ? ((x - rect.left) / rect.width) * 100 : ((y - rect.top) / rect.height) * 100;
+
+    applyRatio(raw);
+  };
+
+  const commitRatio = (): void => {
+    onRatioChange?.(ratioRef.current);
+  };
+
+  const startDrag = (): void => {
+    const onMouseMove = (event: MouseEvent): void => updateRatioFromPoint(event.clientX, event.clientY);
+    const onTouchMove = (event: TouchEvent): void => {
+      const touch = event.touches[0];
+      if (touch) {
+        updateRatioFromPoint(touch.clientX, touch.clientY);
+      }
+    };
+    const onEnd = (): void => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onEnd);
+      document.removeEventListener('touchmove', onTouchMove);
+      document.removeEventListener('touchend', onEnd);
+      commitRatio();
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onEnd);
+    document.addEventListener('touchmove', onTouchMove);
+    document.addEventListener('touchend', onEnd);
+  };
+
+  const handleMouseDown = (event: React.MouseEvent): void => {
+    event.preventDefault();
+    startDrag();
+  };
+
+  const handleTouchStart = (): void => {
+    startDrag();
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent): void => {
+    const decreaseKey = isHorizontal ? 'ArrowLeft' : 'ArrowUp';
+    const increaseKey = isHorizontal ? 'ArrowRight' : 'ArrowDown';
+
+    let next: number | null = null;
+    if (event.key === decreaseKey) {
+      next = ratioRef.current - KEYBOARD_STEP;
+    } else if (event.key === increaseKey) {
+      next = ratioRef.current + KEYBOARD_STEP;
+    } else if (event.key === 'Home') {
+      next = MIN_RATIO;
+    } else if (event.key === 'End') {
+      next = MAX_RATIO;
+    }
+
+    if (next === null) {
+      return;
+    }
+
+    event.preventDefault();
+    applyRatio(next);
+    commitRatio();
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="split-pane"
+      className={cn(styles['tedi-split-pane'], styles[`tedi-split-pane--${direction}`])}
+    >
+      <div data-testid="split-pane-first" className={styles['tedi-split-pane__pane']} style={{ flexGrow: ratio }}>
+        {first}
+        {highlightedSide === 'first' && <SplitPaneRing direction={direction} side="first" />}
+      </div>
+
+      <div
+        role="separator"
+        tabIndex={0}
+        aria-orientation={isHorizontal ? 'vertical' : 'horizontal'}
+        aria-valuemin={MIN_RATIO}
+        aria-valuemax={MAX_RATIO}
+        aria-valuenow={Math.round(ratio)}
+        aria-label={getLabel('splitPaneResize')}
+        data-testid="split-pane-divider"
+        className={styles['tedi-split-pane__divider']}
+        onMouseDown={handleMouseDown}
+        onTouchStart={handleTouchStart}
+        onKeyDown={handleKeyDown}
+      >
+        <span data-testid="split-pane-handle" aria-hidden className={styles['tedi-split-pane__handle']}>
+          <Icon name={isHorizontal ? 'code' : 'unfold_more'} size={18} />
+        </span>
+
+        {onClose && (
+          <Button
+            data-testid="split-pane-close"
+            visualType="secondary"
+            icon="close"
+            className={styles['tedi-split-pane__close']}
+            onClick={onClose}
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            {getLabel('close')}
+          </Button>
+        )}
+      </div>
+
+      <div
+        data-testid="split-pane-second"
+        className={styles['tedi-split-pane__pane']}
+        style={{ flexGrow: 100 - ratio }}
+      >
+        {second}
+        {highlightedSide === 'second' && <SplitPaneRing direction={direction} side="second" />}
+      </div>
+    </div>
+  );
+};
+
+SplitPane.displayName = 'SplitPane';
+
+export default SplitPane;

--- a/src/community/components/map-components/split-pane/split-pane.tsx
+++ b/src/community/components/map-components/split-pane/split-pane.tsx
@@ -175,16 +175,17 @@ export const SplitPane = (props: SplitPaneProps): JSX.Element => {
         </span>
 
         {onClose && (
-          <Button
-            data-testid="split-pane-close"
-            visualType="secondary"
-            icon="close"
-            className={styles['tedi-split-pane__close']}
-            onClick={onClose}
-            onMouseDown={(event) => event.stopPropagation()}
-          >
-            {getLabel('close')}
-          </Button>
+          <div className={styles['tedi-split-pane__close']}>
+            <Button
+              data-testid="split-pane-close"
+              visualType="secondary"
+              icon="close"
+              onClick={onClose}
+              onMouseDown={(event) => event.stopPropagation()}
+            >
+              {getLabel('close')}
+            </Button>
+          </div>
         )}
       </div>
 

--- a/src/community/components/map-components/split-pane/split-pane.tsx
+++ b/src/community/components/map-components/split-pane/split-pane.tsx
@@ -20,19 +20,29 @@ export interface SplitPaneProps {
   /** When provided, renders a close button on the divider. */
   onClose?: () => void;
   /**
-   * Initial size of the first pane as a percentage of the container, clamped to 20–80.
+   * Initial size of the first pane as a percentage of the container, clamped to `minRatio`–`maxRatio`.
    * @default 50
    */
   initialRatio?: number;
+  /**
+   * Minimum size of the first pane, as a percentage of the container.
+   * @default 20
+   */
+  minRatio?: number;
+  /**
+   * Maximum size of the first pane, as a percentage of the container.
+   * @default 80
+   */
+  maxRatio?: number;
   /** Called with the final ratio (%) when a drag or keyboard adjustment event ends. */
   onRatioChange?: (ratio: number) => void;
 }
 
-const MIN_RATIO = 20;
-const MAX_RATIO = 80;
+const DEFAULT_MIN_RATIO = 20;
+const DEFAULT_MAX_RATIO = 80;
 const KEYBOARD_STEP = 2;
 
-const clampRatio = (value: number): number => Math.max(MIN_RATIO, Math.min(MAX_RATIO, value));
+const clampRatio = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
 
 const getOmittedEdge = (isHorizontal: boolean, side: PaneSide): PaneEdge => {
   if (isHorizontal) {
@@ -60,10 +70,20 @@ const SplitPaneRing = ({ direction, side }: SplitPaneRingProps): JSX.Element => 
 };
 
 export const SplitPane = (props: SplitPaneProps): JSX.Element => {
-  const { first, second, direction, highlightedSide, onClose, initialRatio = 50, onRatioChange } = props;
+  const {
+    first,
+    second,
+    direction,
+    highlightedSide,
+    onClose,
+    initialRatio = 50,
+    minRatio = DEFAULT_MIN_RATIO,
+    maxRatio = DEFAULT_MAX_RATIO,
+    onRatioChange,
+  } = props;
   const { getLabel } = useLabels();
 
-  const [ratio, setRatio] = useState<number>(() => clampRatio(initialRatio));
+  const [ratio, setRatio] = useState<number>(() => clampRatio(initialRatio, minRatio, maxRatio));
   const ratioRef = useRef<number>(ratio);
   const containerRef = useRef<HTMLDivElement>(null);
   const dragCleanupRef = useRef<(() => void) | null>(null);
@@ -71,7 +91,7 @@ export const SplitPane = (props: SplitPaneProps): JSX.Element => {
   const isHorizontal = direction === 'horizontal';
 
   const applyRatio = (next: number): void => {
-    const clamped = clampRatio(next);
+    const clamped = clampRatio(next, minRatio, maxRatio);
     ratioRef.current = clamped;
     setRatio(clamped);
   };
@@ -148,9 +168,9 @@ export const SplitPane = (props: SplitPaneProps): JSX.Element => {
     } else if (event.key === increaseKey) {
       next = ratioRef.current + KEYBOARD_STEP;
     } else if (event.key === 'Home') {
-      next = MIN_RATIO;
+      next = minRatio;
     } else if (event.key === 'End') {
-      next = MAX_RATIO;
+      next = maxRatio;
     }
 
     if (next === null) {
@@ -177,8 +197,8 @@ export const SplitPane = (props: SplitPaneProps): JSX.Element => {
         role="separator"
         tabIndex={0}
         aria-orientation={isHorizontal ? 'vertical' : 'horizontal'}
-        aria-valuemin={MIN_RATIO}
-        aria-valuemax={MAX_RATIO}
+        aria-valuemin={minRatio}
+        aria-valuemax={maxRatio}
         aria-valuenow={Math.round(ratio)}
         aria-label={getLabel('splitPaneResize')}
         data-testid="split-pane-divider"

--- a/src/community/components/map-components/split-pane/split-pane.tsx
+++ b/src/community/components/map-components/split-pane/split-pane.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames';
-import React, { JSX, ReactNode, useRef, useState } from 'react';
+import React, { JSX, ReactNode, useEffect, useRef, useState } from 'react';
 
 import { Button, Icon, useLabels } from '../../../../tedi';
 import styles from './split-pane.module.scss';
@@ -66,6 +66,7 @@ export const SplitPane = (props: SplitPaneProps): JSX.Element => {
   const [ratio, setRatio] = useState<number>(() => clampRatio(initialRatio));
   const ratioRef = useRef<number>(ratio);
   const containerRef = useRef<HTMLDivElement>(null);
+  const dragCleanupRef = useRef<(() => void) | null>(null);
 
   const isHorizontal = direction === 'horizontal';
 
@@ -81,7 +82,12 @@ export const SplitPane = (props: SplitPaneProps): JSX.Element => {
     }
 
     const rect = containerRef.current.getBoundingClientRect();
-    const raw = isHorizontal ? ((x - rect.left) / rect.width) * 100 : ((y - rect.top) / rect.height) * 100;
+    const size = isHorizontal ? rect.width : rect.height;
+    if (size <= 0) {
+      return;
+    }
+
+    const raw = isHorizontal ? ((x - rect.left) / size) * 100 : ((y - rect.top) / size) * 100;
 
     applyRatio(raw);
   };
@@ -99,11 +105,16 @@ export const SplitPane = (props: SplitPaneProps): JSX.Element => {
       }
     };
     const onEnd = (): void => {
+      dragCleanupRef.current?.();
+      commitRatio();
+    };
+
+    dragCleanupRef.current = (): void => {
       document.removeEventListener('mousemove', onMouseMove);
       document.removeEventListener('mouseup', onEnd);
       document.removeEventListener('touchmove', onTouchMove);
       document.removeEventListener('touchend', onEnd);
-      commitRatio();
+      dragCleanupRef.current = null;
     };
 
     document.addEventListener('mousemove', onMouseMove);
@@ -111,6 +122,12 @@ export const SplitPane = (props: SplitPaneProps): JSX.Element => {
     document.addEventListener('touchmove', onTouchMove);
     document.addEventListener('touchend', onEnd);
   };
+
+  useEffect(() => {
+    return () => {
+      dragCleanupRef.current?.();
+    };
+  }, []);
 
   const handleMouseDown = (event: React.MouseEvent): void => {
     event.preventDefault();

--- a/src/community/index.ts
+++ b/src/community/index.ts
@@ -57,4 +57,5 @@ export * from './components/map-components/right-panel/right-panel';
 export * from './components/map-components/scale-bar/scale-bar';
 export * from './components/map-components/map-select/map-select';
 export * from './components/map-components/sheet/sheet';
+export * from './components/map-components/split-pane/split-pane';
 export * from './components/map-components/timeline/timeline';

--- a/src/tedi/providers/label-provider/labels-map.ts
+++ b/src/tedi/providers/label-provider/labels-map.ts
@@ -86,6 +86,13 @@ export const labelsMap = validateDefaultLabels({
     en: 'Close',
     ru: 'Закрыть',
   },
+  splitPaneResize: {
+    description: 'Accessible label for the SplitPane resize divider',
+    components: ['SplitPane'],
+    et: 'Muuda paanide suurust',
+    en: 'Resize panes',
+    ru: 'Изменить размер панелей',
+  },
   open: {
     description: 'Used for opening',
     components: ['Accordion', 'Collapse'],


### PR DESCRIPTION
https://storybook.tedi.ee/react/feat/727-new-SplitPane-component/?path=/docs/community-map-components-splitpane--docs

Added a new SplitPane component into the Map Components subfolder. Resolves [issue 727](https://github.com/TEDI-Design-System/react/issues/727)

This change is related to the development of XGIS3D.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new split-pane component with draggable resizing in both horizontal and vertical orientations.
  * Added optional highlighted side styling and an optional close button.
  * Added improved keyboard and touch interactions for resizing.
  * Added localized accessibility labels for split-pane controls.
* **Tests**
  * Added tests covering rendering, accessibility attributes, pointer/touch and keyboard resizing behavior, ratio clamping, and close-button interactions.
* **Documentation**
  * Added Storybook examples for the split-pane in multiple configurations (default, vertical, highlighted side, close button, custom initial ratio).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->