### PR TITLE
fix(top-nav): fix nav toggle label styles #730

### DIFF
--- a/src/tedi/components/layout/mobile-nav/components/mobile-nav-toggle/mobile-nav-toggle.module.scss
+++ b/src/tedi/components/layout/mobile-nav/components/mobile-nav-toggle/mobile-nav-toggle.module.scss
@@ -36,14 +36,13 @@ $toggle-button-width: 3.5rem;
   &.tedi-mobile-nav-toggle--with-label {
     display: inline-flex;
     flex-direction: column;
-    gap: var(--tedi-spacing-04);
     align-items: center;
     justify-content: center;
     width: auto;
     min-width: $toggle-button-width;
     height: auto;
     min-height: $toggle-button-height;
-    padding: var(--tedi-spacing-08);
+    padding: 0;
     color: var(--button-main-primary-text-default);
     cursor: pointer;
     background-color: var(--button-main-primary-background-default);
@@ -69,7 +68,7 @@ $toggle-button-width: 3.5rem;
 }
 
 .tedi-mobile-nav-toggle__label {
-  font-size: var(--body-extra-small-regular-size);
-  font-weight: var(--body-extra-small-regular-weight);
-  line-height: 1;
+  font-size: var(--body-extra-small-size);
+  font-weight: var(--body-extra-small-weight);
+  line-height: var(--body-extra-small-line-height);
 }

--- a/src/tedi/components/layout/top-nav/top-nav.stories.tsx
+++ b/src/tedi/components/layout/top-nav/top-nav.stories.tsx
@@ -42,7 +42,8 @@ const MobileNavStateContext = createContext<{
 } | null>(null);
 
 /**
- * <a href="https://www.figma.com/design/jWiRIXhHRxwVdMSimKX2FF/TEDI-READY-2.46.70?node-id=31693-133265&m=dev" target="_BLANK">Figma ↗</a>
+ * <a href="https://www.figma.com/design/jWiRIXhHRxwVdMSimKX2FF/TEDI-READY-2.46.70?node-id=31693-133265&m=dev" target="_BLANK">Figma ↗</a><br />
+ * <a href="https://www.tedi.ee/1ee8444b7/p/033a20-top-navigation" target="_BLANK">Zeroheight ↗</a>
  */
 const meta: Meta<typeof TopNav> = {
   component: TopNav,


### PR DESCRIPTION
https://storybook.tedi.ee/react/fix/730-nav-toggle-label-has-incorrect-font-size/?path=/story/tedi-ready-layout-topnav--default&globals=viewport.value:mobile1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined the mobile navigation toggle’s labeled state for improved alignment and spacing.
  * Adjusted sizing to reuse the shared toggle button dimensions and removed extra padding.
  * Updated label typography to use the smaller “body extra small” scale for more consistent text styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->