### PR TITLE
fix(map-button): Added prop functionalities to map-button #740

### DIFF
--- a/src/community/components/map-components/button-group/button-group.module.scss
+++ b/src/community/components/map-components/button-group/button-group.module.scss
@@ -3,7 +3,8 @@
 .tedi-button-group {
   display: flex;
   gap: 0;
-  overflow: hidden;
+  width: fit-content;
+  overflow: visible;
 
   &--horizontal {
     flex-direction: row;
@@ -43,7 +44,6 @@
 
   &--vertical {
     flex-direction: column;
-    width: fit-content;
 
     .tedi-button-group__item {
       &:first-child {
@@ -70,6 +70,7 @@
     .tedi-button-group__prefix {
       align-self: stretch;
       min-width: 0;
+      padding: 0;
 
       > span {
         overflow: hidden;
@@ -91,6 +92,7 @@
   }
 
   .tedi-button-group__item {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -99,12 +101,20 @@
     cursor: pointer;
     border-radius: 0;
 
+    &:hover,
+    &:focus-visible,
+    &--active {
+      z-index: 1;
+    }
+
     @include breakpoints.media-breakpoint-down(md) {
       flex: 1;
     }
   }
 
   &--stretch {
+    width: 100%;
+
     .tedi-button-group__item {
       flex: 1;
     }

--- a/src/community/components/map-components/button-group/button-group.module.scss
+++ b/src/community/components/map-components/button-group/button-group.module.scss
@@ -36,13 +36,14 @@
 
     .tedi-button-group__prefix {
       border-right: 0;
-      border-bottom-right-radius: var(--button-radius-sm);
+      border-top-left-radius: var(--button-radius-sm);
       border-bottom-left-radius: var(--button-radius-sm);
     }
   }
 
   &--vertical {
     flex-direction: column;
+    width: fit-content;
 
     .tedi-button-group__item {
       &:first-child {
@@ -67,7 +68,8 @@
 
     .tedi-button-group__suffix,
     .tedi-button-group__prefix {
-      width: var(--tedi-dimensions-16);
+      align-self: stretch;
+      min-width: 0;
 
       > span {
         overflow: hidden;

--- a/src/community/components/map-components/map-button/map-button.module.scss
+++ b/src/community/components/map-components/map-button/map-button.module.scss
@@ -7,16 +7,18 @@
   font-size: var(--tedi-size-00);
   font-weight: 700;
   color: var(--button-primary-text-default);
+  cursor: pointer;
   background-color: var(--button-primary-background-default);
   border: 1px solid var(--button-primary-border-default);
   border-radius: var(--button-radius-sm);
 
+  &--is-hovered:not(:disabled, [aria-disabled='true']),
   &:hover:not(:disabled, [aria-disabled='true']) {
-    cursor: pointer;
     background-color: var(--button-primary-background-hover);
     border-color: var(--button-primary-border-hover);
   }
 
+  &--is-active:not(:disabled, [aria-disabled='true']),
   &:active:not(:disabled, [aria-disabled='true']) {
     color: var(--button-primary-text-active);
     background-color: var(--button-primary-background-hover);
@@ -83,21 +85,6 @@
     .tedi-map-button__icon {
       color: var(--button-primary-text-active);
     }
-  }
-
-  &--is-active:not(:disabled, [aria-disabled='true']) {
-    color: var(--button-primary-text-active);
-    background-color: var(--button-primary-background-hover);
-    border-color: var(--button-primary-border-active);
-
-    .tedi-map-button__icon {
-      color: var(--button-primary-text-active);
-    }
-  }
-
-  &--is-hovered:not(:disabled, [aria-disabled='true']) {
-    background-color: var(--button-primary-background-hover);
-    border-color: var(--button-primary-border-hover);
   }
 
   &--underline {

--- a/src/community/components/map-components/map-button/map-button.module.scss
+++ b/src/community/components/map-components/map-button/map-button.module.scss
@@ -11,13 +11,13 @@
   border: 1px solid var(--button-primary-border-default);
   border-radius: var(--button-radius-sm);
 
-  &:hover {
+  &:hover:not(:disabled, [aria-disabled='true']) {
     cursor: pointer;
     background-color: var(--button-primary-background-hover);
     border-color: var(--button-primary-border-hover);
   }
 
-  &:active {
+  &:active:not(:disabled, [aria-disabled='true']) {
     color: var(--button-primary-text-active);
     background-color: var(--button-primary-background-hover);
     border-color: var(--button-primary-border-active);
@@ -27,10 +27,25 @@
     }
   }
 
-  &:focus-visible {
+  &:focus-visible:not(:disabled, [aria-disabled='true']) {
     outline: var(--tedi-borders-02) solid var(--tedi-primary-500);
     outline-offset: 1px;
     border-color: var(--button-primary-border-hover);
+  }
+
+  &:disabled,
+  &[aria-disabled='true'] {
+    cursor: auto;
+  }
+
+  &:disabled {
+    color: var(--button-main-disabled-general-text);
+    background-color: var(--button-main-disabled-general-background);
+    border-color: var(--button-main-disabled-general-border);
+
+    .tedi-map-button__icon {
+      color: var(--button-main-disabled-general-text);
+    }
   }
 
   &__text {
@@ -58,7 +73,7 @@
     }
   }
 
-  &--selected {
+  &--selected:not(:disabled, [aria-disabled='true']) {
     color: var(--button-primary-text-active);
     outline: 2px solid var(--button-primary-border-active);
     outline-offset: -2px;
@@ -67,6 +82,27 @@
 
     .tedi-map-button__icon {
       color: var(--button-primary-text-active);
+    }
+  }
+
+  &--active:not(:disabled, [aria-disabled='true']) {
+    color: var(--button-primary-text-active);
+    background-color: var(--button-primary-background-hover);
+    border-color: var(--button-primary-border-active);
+
+    .tedi-map-button__icon {
+      color: var(--button-primary-text-active);
+    }
+  }
+
+  &--is-hovered:not(:disabled, [aria-disabled='true']) {
+    background-color: var(--button-primary-background-hover);
+    border-color: var(--button-primary-border-hover);
+  }
+
+  &--underline {
+    .tedi-map-button__text {
+      text-decoration: underline;
     }
   }
 

--- a/src/community/components/map-components/map-button/map-button.module.scss
+++ b/src/community/components/map-components/map-button/map-button.module.scss
@@ -85,7 +85,7 @@
     }
   }
 
-  &--active:not(:disabled, [aria-disabled='true']) {
+  &--is-active:not(:disabled, [aria-disabled='true']) {
     color: var(--button-primary-text-active);
     background-color: var(--button-primary-background-hover);
     border-color: var(--button-primary-border-active);

--- a/src/community/components/map-components/map-button/map-button.spec.tsx
+++ b/src/community/components/map-components/map-button/map-button.spec.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+// The `src/tedi` barrel transitively imports react-sticky-box (ESM-only), which Jest does not transform.
+jest.mock('react-sticky-box', () => ({ __esModule: true, default: () => null }));
+
+import { MapButton } from './map-button';
+
+describe('MapButton', () => {
+  it('renders its label', () => {
+    render(<MapButton>Mõõda</MapButton>);
+    expect(screen.getByRole('button', { name: 'Mõõda' })).toBeInTheDocument();
+  });
+
+  it('is disabled and does not fire onClick when disabled', () => {
+    const onClick = jest.fn();
+    render(
+      <MapButton disabled onClick={onClick}>
+        Text
+      </MapButton>
+    );
+    const btn = screen.getByRole('button');
+    expect(btn).toBeDisabled();
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('blocks onClick and marks busy while loading', () => {
+    const onClick = jest.fn();
+    render(
+      <MapButton isLoading onClick={onClick}>
+        Text
+      </MapButton>
+    );
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('applies the underline / is-hovered modifier classes', () => {
+    const { rerender } = render(<MapButton underline>Text</MapButton>);
+    expect(screen.getByRole('button').className).toContain('tedi-map-button--underline');
+
+    rerender(<MapButton isHovered>Text</MapButton>);
+    expect(screen.getByRole('button').className).toContain('tedi-map-button--is-hovered');
+  });
+});

--- a/src/community/components/map-components/map-button/map-button.spec.tsx
+++ b/src/community/components/map-components/map-button/map-button.spec.tsx
@@ -37,11 +37,14 @@ describe('MapButton', () => {
     expect(onClick).not.toHaveBeenCalled();
   });
 
-  it('applies the underline / is-hovered modifier classes', () => {
+  it('applies the underline / is-hovered / active modifier classes', () => {
     const { rerender } = render(<MapButton underline>Text</MapButton>);
     expect(screen.getByRole('button').className).toContain('tedi-map-button--underline');
 
     rerender(<MapButton isHovered>Text</MapButton>);
     expect(screen.getByRole('button').className).toContain('tedi-map-button--is-hovered');
+
+    rerender(<MapButton isActive>Text</MapButton>);
+    expect(screen.getByRole('button').className).toContain('tedi-map-button--is-active');
   });
 });

--- a/src/community/components/map-components/map-button/map-button.stories.tsx
+++ b/src/community/components/map-components/map-button/map-button.stories.tsx
@@ -53,7 +53,7 @@ const TemplateColumn: StoryFn<TemplateMultipleProps> = (args) => {
               <MapButton id={value} {...buttonProps} selected={value === 'Selected'}>
                 Text
               </MapButton>
-              <MapButton id={value} {...buttonProps} iconRight="straighten" selected={value === 'Selected'}>
+              <MapButton id={value} {...buttonProps} icon="straighten" selected={value === 'Selected'}>
                 Text
               </MapButton>
               <MapButton id={value} {...buttonProps} selected={value === 'Selected'}>
@@ -67,16 +67,10 @@ const TemplateColumn: StoryFn<TemplateMultipleProps> = (args) => {
               <MapButton id={value} size="small" {...buttonProps} selected={value === 'Selected'}>
                 Text
               </MapButton>
-              <MapButton
-                id={value}
-                size="small"
-                {...buttonProps}
-                iconRight="straighten"
-                selected={value === 'Selected'}
-              >
+              <MapButton id={value} size="small" {...buttonProps} icon="straighten" selected={value === 'Selected'}>
                 Text
               </MapButton>
-              <MapButton id={value} size="small" {...buttonProps} iconLeft="edit" selected={value === 'Selected'}>
+              <MapButton id={value} size="small" {...buttonProps} icon="edit" selected={value === 'Selected'}>
                 Text
               </MapButton>
               <MapButton
@@ -109,6 +103,29 @@ export const HideLabel: Story = {
     hideLabel: true,
     icon: 'straighten',
     size: 'small',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    children: 'Text',
+    icon: 'straighten',
+    disabled: true,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    children: 'Text',
+    icon: 'straighten',
+    isLoading: true,
+  },
+};
+
+export const Underline: Story = {
+  args: {
+    children: 'Text',
+    underline: true,
   },
 };
 
@@ -163,7 +180,7 @@ export const States: StoryObj<TemplateMultipleProps> = {
 const TemplateGroup: StoryFn<ButtonGroupProps> = (args) => {
   return (
     <ButtonGroup {...args}>
-      <MapButton icon="location_on">Punkt</MapButton>
+      <MapButton icon="explore">Kompass</MapButton>
       <MapButton icon="straighten">Mõõda</MapButton>
       <MapButton icon="compare">Võrdle</MapButton>
       <MapButton icon="history">Ajajoon</MapButton>
@@ -171,8 +188,24 @@ const TemplateGroup: StoryFn<ButtonGroupProps> = (args) => {
   );
 };
 
+// meta.component is MapButton, so Storybook infers MapButton's controls. For the ButtonGroup
+// stories we declare ButtonGroup's argTypes explicitly and restrict the Controls panel to them.
+const buttonGroupArgTypes: Meta<typeof ButtonGroup>['argTypes'] = {
+  direction: { control: 'radio', options: ['horizontal', 'vertical'] },
+  stretch: { control: 'boolean' },
+  prefix: { control: 'text' },
+  suffix: { control: 'text' },
+  ariaLabel: { control: 'text' },
+};
+
+const buttonGroupParameters: Meta<typeof ButtonGroup>['parameters'] = {
+  controls: { include: ['direction', 'stretch', 'prefix', 'suffix', 'ariaLabel'] },
+};
+
 export const ButtonGroupHorizontal: StoryObj<ButtonGroupProps> = {
   render: TemplateGroup,
+  argTypes: buttonGroupArgTypes,
+  parameters: buttonGroupParameters,
   args: {
     direction: 'horizontal',
   },
@@ -180,53 +213,33 @@ export const ButtonGroupHorizontal: StoryObj<ButtonGroupProps> = {
 
 export const ButtonGroupVertical: StoryObj<ButtonGroupProps> = {
   render: TemplateGroup,
+  argTypes: buttonGroupArgTypes,
+  parameters: buttonGroupParameters,
   args: {
     direction: 'vertical',
   },
 };
 
-export const ButtonGroupHorizontalSuffixAndPrefix: StoryFn<ButtonGroupProps> = (args) => {
-  return (
-    <VerticalSpacing>
-      <ButtonGroup suffix="Suffix" ariaLabel="Example button group">
-        <MapButton id="btn1" size="small" icon="location_on">
-          Button 1
-        </MapButton>
-        <MapButton id="btn2" size="small" icon="history">
-          Button 2
-        </MapButton>
-      </ButtonGroup>
-      <ButtonGroup prefix="Prefix" ariaLabel="Example button group">
-        <MapButton id="btn1" size="small" icon="location_on">
-          Button 1
-        </MapButton>
-        <MapButton id="btn2" size="small" icon="history">
-          Button 2
-        </MapButton>
-      </ButtonGroup>
-    </VerticalSpacing>
-  );
+export const ButtonGroupHorizontalWithPrefixAndSuffix: StoryObj<ButtonGroupProps> = {
+  render: TemplateGroup,
+  argTypes: buttonGroupArgTypes,
+  parameters: buttonGroupParameters,
+  args: {
+    direction: 'horizontal',
+    prefix: 'Prefix',
+    suffix: 'Suffix',
+    ariaLabel: 'Example button group',
+  },
 };
 
-export const ButtonGroupHVerticalSuffixAndPrefix: StoryFn<ButtonGroupProps> = (args) => {
-  return (
-    <VerticalSpacing>
-      <ButtonGroup suffix="0" ariaLabel="Example button group" direction="vertical">
-        <MapButton id="btn1" size="small" icon="location_on">
-          Button 1
-        </MapButton>
-        <MapButton id="btn2" size="small" icon="history">
-          Button 2
-        </MapButton>
-      </ButtonGroup>
-      <ButtonGroup prefix="0" ariaLabel="Example button group" direction="vertical">
-        <MapButton id="btn1" size="small" icon="location_on">
-          Button 1
-        </MapButton>
-        <MapButton id="btn2" size="small" icon="history">
-          Button 2
-        </MapButton>
-      </ButtonGroup>
-    </VerticalSpacing>
-  );
+export const ButtonGroupVerticalWithPrefixAndSuffix: StoryObj<ButtonGroupProps> = {
+  render: TemplateGroup,
+  argTypes: buttonGroupArgTypes,
+  parameters: buttonGroupParameters,
+  args: {
+    direction: 'vertical',
+    prefix: '360°',
+    suffix: '360°',
+    ariaLabel: 'Example button group',
+  },
 };

--- a/src/community/components/map-components/map-button/map-button.stories.tsx
+++ b/src/community/components/map-components/map-button/map-button.stories.tsx
@@ -188,6 +188,25 @@ const TemplateGroup: StoryFn<ButtonGroupProps> = (args) => {
   );
 };
 
+const TemplateGroupSmall: StoryFn<ButtonGroupProps> = (args) => {
+  return (
+    <ButtonGroup {...args}>
+      <MapButton size="small" icon="explore">
+        Kompass
+      </MapButton>
+      <MapButton size="small" icon="straighten">
+        Mõõda
+      </MapButton>
+      <MapButton size="small" icon="compare">
+        Võrdle
+      </MapButton>
+      <MapButton size="small" icon="history">
+        Ajajoon
+      </MapButton>
+    </ButtonGroup>
+  );
+};
+
 // meta.component is MapButton, so Storybook infers MapButton's controls. For the ButtonGroup
 // stories we declare ButtonGroup's argTypes explicitly and restrict the Controls panel to them.
 const buttonGroupArgTypes: Meta<typeof ButtonGroup>['argTypes'] = {
@@ -234,6 +253,18 @@ export const ButtonGroupHorizontalWithPrefixAndSuffix: StoryObj<ButtonGroupProps
 
 export const ButtonGroupVerticalWithPrefixAndSuffix: StoryObj<ButtonGroupProps> = {
   render: TemplateGroup,
+  argTypes: buttonGroupArgTypes,
+  parameters: buttonGroupParameters,
+  args: {
+    direction: 'vertical',
+    prefix: '360°',
+    suffix: '360°',
+    ariaLabel: 'Example button group',
+  },
+};
+
+export const ButtonGroupVerticalSmallWithPrefixAndSuffix: StoryObj<ButtonGroupProps> = {
+  render: TemplateGroupSmall,
   argTypes: buttonGroupArgTypes,
   parameters: buttonGroupParameters,
   args: {

--- a/src/community/components/map-components/map-button/map-button.tsx
+++ b/src/community/components/map-components/map-button/map-button.tsx
@@ -1,11 +1,27 @@
 import cn from 'classnames';
 import { JSX, useState } from 'react';
 
-import { Button, ButtonProps, Icon, Tooltip } from '../../../../tedi';
+import { Button, ButtonProps, Icon, Spinner, Tooltip } from '../../../../tedi';
 import MapDropdown, { MapDropdownItem } from '../map-dropdown/map-dropdown';
 import styles from './map-button.module.scss';
 
-export interface MapButtonProps extends Omit<ButtonProps, 'size'> {
+/**
+ * Button props that don't apply to MapButton because it renders `<Button noStyle>` with its own
+ * fixed styling. Omitted so the public API only advertises props that actually work here.
+ */
+type OmittedButtonProps =
+  | 'size'
+  | 'icon'
+  | 'iconLeft'
+  | 'iconRight'
+  | 'visualType'
+  | 'color'
+  | 'fullWidth'
+  | 'showTooltip'
+  | 'noStyle'
+  | 'renderWrapperElement';
+
+export interface MapButtonProps extends Omit<ButtonProps, OmittedButtonProps> {
   /**
    * Size of the button. Can be:
    * - `'default'` – standard size.
@@ -13,8 +29,8 @@ export interface MapButtonProps extends Omit<ButtonProps, 'size'> {
    */
   size?: 'default' | 'small';
   /**
-   * Name of the icon to display inside the button (e.g., Material Symbols name).
-   * If set, the icon appears alongside or instead of the label.
+   * Name of the icon to display above the label (e.g., Material Symbols name).
+   * Replaced by a spinner while `isLoading` is `true`.
    */
   icon?: string;
   /**
@@ -49,6 +65,10 @@ export const MapButton = (props: MapButtonProps): JSX.Element => {
     hideLabel = false,
     tooltipContent = children,
     dropdownItems,
+    isActive,
+    isHovered,
+    underline,
+    isLoading,
     ...rest
   } = props;
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -59,18 +79,26 @@ export const MapButton = (props: MapButtonProps): JSX.Element => {
     styles[`tedi-map-button--${size}`],
     isSelected && styles['tedi-map-button--selected'],
     dropdownItems && styles['tedi-map-button--dropdown'],
+    isActive && styles['tedi-map-button--active'],
+    isHovered && styles['tedi-map-button--is-hovered'],
+    underline && styles['tedi-map-button--underline'],
+    isLoading && styles['tedi-map-button--loading'],
     className
   );
 
   const buttonContent = (
     <>
-      {icon && <Icon name={icon} className={styles['tedi-map-button__icon']} size={size === 'small' ? 24 : 18} />}
+      {isLoading ? (
+        <Spinner size={size === 'small' ? 16 : 18} className={styles['tedi-map-button__icon']} />
+      ) : (
+        icon && <Icon name={icon} className={styles['tedi-map-button__icon']} size={size === 'small' ? 24 : 18} />
+      )}
       {!hideLabel && <div className={cn(styles['tedi-map-button__text'])}>{children}</div>}
     </>
   );
 
   const buttonElement = (
-    <Button noStyle className={mapButtonBEM} size={size} {...rest}>
+    <Button noStyle isLoading={isLoading} className={mapButtonBEM} size={size} {...rest}>
       {buttonContent}
     </Button>
   );

--- a/src/community/components/map-components/map-button/map-button.tsx
+++ b/src/community/components/map-components/map-button/map-button.tsx
@@ -79,7 +79,7 @@ export const MapButton = (props: MapButtonProps): JSX.Element => {
     styles[`tedi-map-button--${size}`],
     isSelected && styles['tedi-map-button--selected'],
     dropdownItems && styles['tedi-map-button--dropdown'],
-    isActive && styles['tedi-map-button--active'],
+    isActive && styles['tedi-map-button--is-active'],
     isHovered && styles['tedi-map-button--is-hovered'],
     underline && styles['tedi-map-button--underline'],
     isLoading && styles['tedi-map-button--loading'],


### PR DESCRIPTION
https://storybook.tedi.ee/react/fix/740-MapButton-component-improvements/?path=/docs/community-map-components-mapbutton--docs

Resolves #740


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added loading, underline, active/hovered visual states for map buttons and button groups.
  * Button group stories now include more prefix/suffix and layout variants, with updated icon usage.

* **Bug Fixes**
  * Disabled and aria-disabled map buttons no longer show hover/active/selected styling; click remains blocked.
  * Loading state now displays a spinner (and styling) instead of the icon.

* **UX / Styling**
  * Improved button-group sizing/overflow behavior and stacking (z-index) on interaction; stretch modifier now fills available width.

* **Tests**
  * Added coverage for loading/disabled behavior and modifier styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->