### PR TITLE
feat(date-field): multiple-tag layout, invalid-date error and a11y fixes #721

### DIFF
--- a/src/tedi/components/form/date-field/date-field.spec.tsx
+++ b/src/tedi/components/form/date-field/date-field.spec.tsx
@@ -130,6 +130,52 @@ describe('DateField component', () => {
     expect(onSelect).toHaveBeenCalled();
   });
 
+  it('shows an invalid-date error on blur and keeps the typed value visible', async () => {
+    const user = userEvent.setup();
+    render(<DateField {...defaultProps} />);
+    const input = screen.getByLabelText('Birth date');
+
+    await user.type(input, '33.33.3333');
+    await user.tab();
+
+    expect(screen.getByText('dateField.invalidDateError')).toBeInTheDocument();
+    expect(input).toHaveValue('33.33.3333');
+  });
+
+  it('does not show the invalid-date error for a parseable date', async () => {
+    const user = userEvent.setup();
+    render(<DateField {...defaultProps} />);
+    const input = screen.getByLabelText('Birth date');
+
+    await user.type(input, '15.06.2024');
+    await user.tab();
+
+    expect(screen.queryByText('dateField.invalidDateError')).not.toBeInTheDocument();
+  });
+
+  it('clears the invalid-date error once the user edits the input again', async () => {
+    const user = userEvent.setup();
+    render(<DateField {...defaultProps} />);
+    const input = screen.getByLabelText('Birth date');
+
+    await user.type(input, '33.33.3333');
+    await user.tab();
+    expect(screen.getByText('dateField.invalidDateError')).toBeInTheDocument();
+
+    await user.type(input, '1');
+    expect(screen.queryByText('dateField.invalidDateError')).not.toBeInTheDocument();
+  });
+
+  it('gives the calendar toggle button an accessible name (single mode)', () => {
+    render(<DateField {...defaultProps} />);
+    expect(screen.getByRole('button', { name: 'dateField.openCalendar' })).toBeInTheDocument();
+  });
+
+  it('gives the calendar toggle button an accessible name (multiple mode)', () => {
+    render(<DateField {...defaultProps} mode="multiple" />);
+    expect(screen.getByRole('button', { name: 'dateField.openCalendar' })).toBeInTheDocument();
+  });
+
   it('updates when controlled value changes', () => {
     const { rerender } = render(<DateField {...defaultProps} selected={undefined} />);
     rerender(<DateField {...defaultProps} selected={new Date(2024, 5, 15)} />);

--- a/src/tedi/components/form/date-field/date-field.spec.tsx
+++ b/src/tedi/components/form/date-field/date-field.spec.tsx
@@ -351,6 +351,19 @@ describe('DateField component', () => {
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
   });
 
+  it('links the calendar trigger to the popover via aria-controls when open', async () => {
+    const user = userEvent.setup();
+
+    render(<DateField {...defaultProps} />);
+
+    const button = screen.getByRole('button', { name: 'dateField.openCalendar' });
+    await user.click(button);
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog.id).toBeTruthy();
+    expect(button).toHaveAttribute('aria-controls', dialog.id);
+  });
+
   it('closes calendar when clicking icon again (button trigger toggle)', async () => {
     const user = userEvent.setup();
 

--- a/src/tedi/components/form/date-field/date-field.stories.tsx
+++ b/src/tedi/components/form/date-field/date-field.stories.tsx
@@ -316,6 +316,62 @@ export const MultipleValues: Story = {
   },
 };
 
+/**
+ * `tagsDirection` controls how the selected-date tags lay out in `mode="multiple"`.
+ * `'stack'` (default) wraps them onto multiple rows and grows the field height;
+ * `'row'` keeps them on a single row and collapses the overflow into a `+N`
+ * counter (measured from the available width, like `Select`).
+ */
+export const MultipleTagLayout: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => {
+    const preset = Array.from({ length: 8 }, (_, i) => new Date(2025, 0, i + 1));
+    const [rowValue, setRowValue] = useState<Date[]>(preset);
+    const [stackValue, setStackValue] = useState<Date[]>(preset);
+
+    const formatDate = (date: Date | Date[] | DateRange | undefined): string => {
+      const fmt = new Intl.DateTimeFormat('et-EE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+      if (!date) return '';
+      if (date instanceof Date) return fmt.format(date);
+      if (Array.isArray(date)) return date.map((d) => fmt.format(d)).join(', ');
+      if ('from' in date && date.from) {
+        return date.to ? `${fmt.format(date.from)} – ${fmt.format(date.to)}` : fmt.format(date.from);
+      }
+      return '';
+    };
+
+    const toDates = (selected: Date | Date[] | DateRange | undefined): Date[] =>
+      Array.isArray(selected) ? selected : selected instanceof Date ? [selected] : [];
+
+    return (
+      <Row gutterY={3}>
+        <Col xs={12} md={6}>
+          <DateField
+            mode="multiple"
+            label="Üherealine (+N)"
+            placeholder="pp.kk.aaaa"
+            tagsDirection="row"
+            selected={rowValue}
+            onSelect={(selected) => setRowValue(toDates(selected))}
+            formatDate={formatDate}
+          />
+        </Col>
+        <Col xs={12} md={6}>
+          <DateField
+            mode="multiple"
+            label="Mitmerealine (vaikimisi)"
+            placeholder="pp.kk.aaaa"
+            tagsDirection="stack"
+            selected={stackValue}
+            onSelect={(selected) => setStackValue(toDates(selected))}
+            formatDate={formatDate}
+          />
+        </Col>
+      </Row>
+    );
+  },
+};
+
 export const Range: Story = {
   render: () => {
     const [defaultRange, setDefaultRange] = useState<DateRange | undefined>();

--- a/src/tedi/components/form/date-field/date-field.stories.tsx
+++ b/src/tedi/components/form/date-field/date-field.stories.tsx
@@ -162,20 +162,27 @@ export const FieldOptions: StoryFn = () => {
     <Row>
       <Col lg={6} xs={12}>
         <div className="flex gap-4 flex-column">
-          <DateField id="date-default" label="Kuupäeva väli vaikimisi" placeholder="pp.kk.aaaa" mode="single" />
-
-          <DateField
-            id="date-with-hint"
-            label="Kuupäeva väli vihjega"
-            placeholder="pp.kk.aaaa"
-            mode="single"
-            inputProps={{ helper: { text: 'pp.kk.aaaa' } }}
-          />
+          <div>
+            <p style={{ marginBottom: '8px', display: 'block' }}>Default date field</p>
+            <DateField id="date-default" label="Kuupäev" placeholder="pp.kk.aaaa" mode="single" />
+          </div>
 
           <div>
+            <p style={{ marginBottom: '8px', display: 'block' }}>Date field with helper text</p>
+            <DateField
+              id="date-with-hint"
+              label="Kuupäev"
+              placeholder="pp.kk.aaaa"
+              mode="single"
+              inputProps={{ helper: { text: 'pp.kk.aaaa' } }}
+            />
+          </div>
+
+          <div>
+            <p style={{ marginBottom: '8px', display: 'block' }}>Date field with quick-select shortcuts</p>
             <DateField
               id="date-with-shortcuts"
-              label="Kuupäeva väli kiirvalikutega"
+              label="Kuupäev"
               placeholder="pp.kk.aaaa"
               mode="single"
               selected={shortcutValue}
@@ -346,9 +353,10 @@ export const MultipleTagLayout: Story = {
     return (
       <Row gutterY={3}>
         <Col xs={12} md={6}>
+          <p style={{ marginBottom: '8px', display: 'block' }}>Single row — overflow collapses into a +N counter</p>
           <DateField
             mode="multiple"
-            label="Üherealine (+N)"
+            label="Kuupäevad"
             placeholder="pp.kk.aaaa"
             tagsDirection="row"
             selected={rowValue}
@@ -357,9 +365,10 @@ export const MultipleTagLayout: Story = {
           />
         </Col>
         <Col xs={12} md={6}>
+          <p style={{ marginBottom: '8px', display: 'block' }}>Multiple rows (default) — the field grows in height</p>
           <DateField
             mode="multiple"
-            label="Mitmerealine (vaikimisi)"
+            label="Kuupäevad"
             placeholder="pp.kk.aaaa"
             tagsDirection="stack"
             selected={stackValue}
@@ -386,9 +395,10 @@ export const Range: Story = {
     return (
       <Row gutterY={3}>
         <Col lg={6} xs={12}>
+          <p style={{ marginBottom: '8px', display: 'block' }}>Default range</p>
           <DateField
             mode="range"
-            label="Vaikimisi vahemik"
+            label="Vahemik"
             placeholder="pp.kk.aaaa – pp.kk.aaaa"
             selected={defaultRange}
             onSelect={(range) => setDefaultRange(range as DateRange)}
@@ -397,9 +407,10 @@ export const Range: Story = {
         </Col>
 
         <Col lg={6} xs={12}>
+          <p style={{ marginBottom: '8px', display: 'block' }}>Future dates disabled (min/max)</p>
           <DateField
             mode="range"
-            label="Vahemik keelatud tulevikuga"
+            label="Vahemik"
             placeholder="pp.kk.aaaa – pp.kk.aaaa"
             selected={rangeWithLimits}
             onSelect={(range) => setRangeWithLimits(range as DateRange)}
@@ -410,9 +421,10 @@ export const Range: Story = {
         </Col>
 
         <Col lg={6} xs={12}>
+          <p style={{ marginBottom: '8px', display: 'block' }}>Start date only (no end selected)</p>
           <DateField
             mode="range"
-            label="Ainult alguskuupäev"
+            label="Vahemik"
             placeholder="pp.kk.aaaa – pp.kk.aaaa"
             selected={startOnly}
             onSelect={(range) => setStartOnly(range as DateRange)}
@@ -421,9 +433,10 @@ export const Range: Story = {
         </Col>
 
         <Col lg={6} xs={12}>
+          <p style={{ marginBottom: '8px', display: 'block' }}>Past dates disabled</p>
           <DateField
             mode="range"
-            label="Vahemik keelatud minevikuga"
+            label="Vahemik"
             placeholder="pp.kk.aaaa – pp.kk.aaaa"
             selected={disablePastRange}
             onSelect={(range) => setDisablePastRange(range as DateRange)}
@@ -432,9 +445,10 @@ export const Range: Story = {
           />
         </Col>
         <Col width={12}>
+          <p style={{ marginBottom: '8px', display: 'block' }}>Two months shown</p>
           <DateField
             mode="range"
-            label="Vahemik mitme kuuga"
+            label="Vahemik"
             placeholder="pp.kk.aaaa – pp.kk.aaaa"
             selected={defaultRange}
             onSelect={(range) => setDefaultRange(range as DateRange)}
@@ -503,23 +517,29 @@ export const YearGrid: Story = {
 export const GridPickerFirst: Story = {
   render: () => {
     return (
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '24px' }}>
-        <DateField
-          id="date-grid-year-first"
-          mode="single"
-          label="Aasta → kuu → päev"
-          placeholder="pp.kk.aaaa"
-          initialView="years"
-          monthYearSelectType="grid"
-        />
-        <DateField
-          id="date-grid-day-first"
-          mode="single"
-          label="Päev → kuu → aasta"
-          placeholder="pp.kk.aaaa"
-          monthYearSelectType="grid"
-        />
-      </div>
+      <Row>
+        <Col lg={6} xs={12}>
+          <p style={{ marginBottom: '8px', display: 'block' }}>Year → month → day</p>
+          <DateField
+            id="date-grid-year-first"
+            mode="single"
+            label="Kuupäev"
+            placeholder="pp.kk.aaaa"
+            initialView="years"
+            monthYearSelectType="grid"
+          />
+        </Col>
+        <Col lg={6} xs={12}>
+          <p style={{ marginBottom: '8px', display: 'block' }}>Day → month → year</p>
+          <DateField
+            id="date-grid-day-first"
+            mode="single"
+            label="Kuupäev"
+            placeholder="pp.kk.aaaa"
+            monthYearSelectType="grid"
+          />
+        </Col>
+      </Row>
     );
   },
 };

--- a/src/tedi/components/form/date-field/date-field.tsx
+++ b/src/tedi/components/form/date-field/date-field.tsx
@@ -28,7 +28,7 @@ import { useLabels } from '../../../providers/label-provider';
 import { UnknownType } from '../../../types/commonTypes';
 import { Calendar } from '../../content/calendar/calendar';
 import type { ModalContentProps } from '../../overlays/modal/modal-content/modal-content';
-import MultiValueField, { MultiValueFieldProps } from '../multi-value-field/multi-value-field';
+import MultiValueField, { MultiValueFieldProps, MultiValueFieldRef } from '../multi-value-field/multi-value-field';
 import TextField, { TextFieldForwardRef, TextFieldProps } from '../textfield/textfield';
 import styles from './date-field.module.scss';
 import {
@@ -272,6 +272,14 @@ export interface DateFieldProps
    */
   inputProps?: DateTextFieldProps | DateMultiValueFieldProps;
   /**
+   * Layout for the selected-date tags in `'multiple'` mode.
+   * - `'stack'` (default) — tags wrap onto multiple rows; the field grows in height.
+   * - `'row'` — tags stay on a single row; any that don't fit collapse into a
+   *   `+N` counter (measured from the available width).
+   * @default stack
+   */
+  tagsDirection?: 'stack' | 'row';
+  /**
    * Open the calendar inside a modal instead of a floating popover. Useful
    * on narrow viewports where a popover overlaps the input itself. Mirrors
    * `TimeField`'s `modal` prop.
@@ -307,6 +315,13 @@ export interface DateFieldProps
    * label.
    */
   disabledDateErrorMessage?: string;
+  /**
+   * Error message rendered below the input when the typed text cannot be parsed
+   * into a valid date for the current `mode`. Validation runs on blur so
+   * partially-typed input isn't flagged mid-typing. Falls back to the localised
+   * `dateField.invalidDateError` label.
+   */
+  invalidDateErrorMessage?: string;
 }
 
 export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((props, ref) => {
@@ -334,6 +349,7 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
     showOutsideDays = true,
     parseDate,
     monthYearSelectType,
+    tagsDirection,
     showNavigation = true,
     selectionLevel = 'days',
     initialView,
@@ -356,6 +372,7 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
     modalProps,
     modalTitle,
     disabledDateErrorMessage = getLabel('dateField.disabledDateError'),
+    invalidDateErrorMessage = getLabel('dateField.invalidDateError'),
     useNativePicker: _useNativePicker,
     enableCalendar: _enableCalendar,
     calendarTrigger: _calendarTrigger,
@@ -381,6 +398,7 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
   const [view, setView] = useState<CalendarView>(initialView ?? selectionLevel);
   const [inputValue, setInputValue] = useState('');
   const [hasDisabledDateError, setHasDisabledDateError] = useState(false);
+  const [hasInvalidDateError, setHasInvalidDateError] = useState(false);
 
   const useModalPicker =
     enableCalendar &&
@@ -395,6 +413,7 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
   const value = isControlled ? selected : internalValue;
 
   const textFieldRef = React.useRef<TextFieldForwardRef | null>(null);
+  const multiValueRef = React.useRef<MultiValueFieldRef | null>(null);
 
   const setTextFieldRef = React.useCallback(
     (node: TextFieldForwardRef | null) => {
@@ -586,21 +605,25 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
     };
   }, [dateFormatter]);
 
+  const parseInputValue = (val: string): Date | Date[] | DateRange | undefined =>
+    (parseDate ?? (mode === 'single' ? defaultParseDate : () => undefined))(val);
+
+  const isParsedValidForMode = (parsed: Date | Date[] | DateRange | undefined): boolean =>
+    (mode === 'single' && parsed instanceof Date) ||
+    (mode === 'multiple' && Array.isArray(parsed)) ||
+    (mode === 'range' && !!parsed && !Array.isArray(parsed) && 'from' in parsed);
+
   const handleInputChange = (val: string) => {
     setInputValue(val);
+    setHasInvalidDateError(false);
 
     if (val.trim() === '') {
       setHasDisabledDateError(false);
       return;
     }
 
-    const parser = parseDate ?? (mode === 'single' ? defaultParseDate : () => undefined);
-    const parsed = parser(val);
-
-    const isValidForMode =
-      (mode === 'single' && parsed instanceof Date) ||
-      (mode === 'multiple' && Array.isArray(parsed)) ||
-      (mode === 'range' && !!parsed && !Array.isArray(parsed) && 'from' in parsed);
+    const parsed = parseInputValue(val);
+    const isValidForMode = isParsedValidForMode(parsed);
 
     if (!isValidForMode) {
       setHasDisabledDateError(false);
@@ -626,6 +649,16 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
     if (parsed instanceof Date) setCurrentMonth(parsed);
 
     if (shouldCloseOnSelect) setOpen(false);
+  };
+
+  // Flag unparseable input on blur (kept visible) so the user gets feedback
+  // instead of the text silently failing to commit.
+  const handleInputBlur = () => {
+    if (inputValue.trim() === '') {
+      setHasInvalidDateError(false);
+      return;
+    }
+    setHasInvalidDateError(!isParsedValidForMode(parseInputValue(inputValue)));
   };
 
   useEffect(() => {
@@ -687,6 +720,18 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
     useRole(context, { role: 'dialog' }),
   ]);
 
+  // Anchor the popover to the input element itself rather than the container
+  // `<div>` (which also holds the label), so an upward flip aligns to the input.
+  // In multiple mode (no single text input) fall back to the container reference —
+  // passing `null` would clear the anchor entirely and mis-position the popover.
+  React.useEffect(() => {
+    const anchorNode =
+      mode === 'multiple'
+        ? multiValueRef.current?.wrapper ?? null
+        : (textFieldRef.current?.input as HTMLElement | undefined) ?? null;
+    refs.setPositionReference(anchorNode ?? refs.reference.current);
+  }, [mode, open, refs]);
+
   const openNativePicker = () => {
     const input = textFieldRef.current?.input as HTMLInputElement | undefined;
     if (!input) return;
@@ -746,26 +791,42 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
     onSelect?.(parsed, parsed as UnknownType, {}, {} as UnknownType);
   };
 
+  const referenceProps = interactions.getReferenceProps(
+    useModalPicker && calendarTrigger === 'input' ? { onClick: () => openCalendar() } : undefined
+  );
+
+  const {
+    role: _role,
+    'aria-expanded': _ariaExpanded,
+    'aria-haspopup': _ariaHaspopup,
+    'aria-controls': _ariaControls,
+    ...containerInteractionProps
+  } = referenceProps;
+
   return (
     <>
       <div
         className={cn(styles['tedi-date-field__container'], className)}
-        {...interactions.getReferenceProps(
-          useModalPicker && calendarTrigger === 'input' ? { onClick: () => openCalendar() } : undefined
-        )}
+        {...containerInteractionProps}
         ref={refs.setReference}
       >
         {mode === 'multiple' ? (
           <MultiValueField
             {...(inputProps as MultiValueFieldProps)}
+            ref={multiValueRef}
             id={id}
             label={label}
+            tagsDirection={tagsDirection}
             values={formattedDatesWithIds.map((item) => item.label)}
             icon="calendar_today"
             onIconClick={openCalendar}
             iconButtonProps={
               enableCalendar
-                ? { 'aria-expanded': useModalPicker ? modalOpen : open, 'aria-haspopup': 'dialog' }
+                ? {
+                    'aria-label': getLabel('dateField.openCalendar'),
+                    'aria-expanded': useModalPicker ? modalOpen : open,
+                    'aria-haspopup': 'dialog',
+                  }
                 : undefined
             }
             isClearable
@@ -799,17 +860,28 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
             onIconClick={openCalendar}
             iconButtonProps={
               enableCalendar && !shouldUseNativePicker
-                ? { 'aria-expanded': useModalPicker ? modalOpen : open, 'aria-haspopup': 'dialog' }
+                ? {
+                    'aria-label': getLabel('dateField.openCalendar'),
+                    'aria-expanded': useModalPicker ? modalOpen : open,
+                    'aria-haspopup': 'dialog',
+                  }
                 : undefined
             }
             onChange={(val) => (shouldUseNativePicker ? handleNativeInputChange(val) : handleInputChange(val))}
+            onBlur={(e) => {
+              if (!shouldUseNativePicker) handleInputBlur();
+              (inputProps as TextFieldProps)?.onBlur?.(e);
+            }}
             required={required}
-            invalid={hasDisabledDateError || (inputProps as TextFieldProps)?.invalid}
+            invalid={hasDisabledDateError || hasInvalidDateError || (inputProps as TextFieldProps)?.invalid}
             helper={(() => {
               const consumerHelper = (inputProps as TextFieldProps)?.helper;
-              const errorHelper = hasDisabledDateError
-                ? { text: disabledDateErrorMessage, type: 'error' as const }
+              const errorText = hasDisabledDateError
+                ? disabledDateErrorMessage
+                : hasInvalidDateError
+                ? invalidDateErrorMessage
                 : null;
+              const errorHelper = errorText ? { text: errorText, type: 'error' as const } : null;
               if (!errorHelper) return consumerHelper;
               if (!consumerHelper) return errorHelper;
               return Array.isArray(consumerHelper) ? [...consumerHelper, errorHelper] : [consumerHelper, errorHelper];

--- a/src/tedi/components/form/date-field/date-field.tsx
+++ b/src/tedi/components/form/date-field/date-field.tsx
@@ -793,9 +793,11 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
     role: _role,
     'aria-expanded': _ariaExpanded,
     'aria-haspopup': _ariaHaspopup,
-    'aria-controls': _ariaControls,
+    'aria-controls': floatingAriaControls,
     ...containerInteractionProps
   } = referenceProps;
+
+  const triggerAriaControls = !useModalPicker ? (floatingAriaControls as string | undefined) : undefined;
 
   return (
     <>
@@ -820,6 +822,7 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
                     'aria-label': getLabel('dateField.openCalendar'),
                     'aria-expanded': useModalPicker ? modalOpen : open,
                     'aria-haspopup': 'dialog',
+                    'aria-controls': triggerAriaControls,
                   }
                 : undefined
             }
@@ -858,6 +861,7 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
                     'aria-label': getLabel('dateField.openCalendar'),
                     'aria-expanded': useModalPicker ? modalOpen : open,
                     'aria-haspopup': 'dialog',
+                    'aria-controls': triggerAriaControls,
                   }
                 : undefined
             }
@@ -888,7 +892,7 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
               ...((inputProps as TextFieldProps)?.input as UnknownType),
               ...(shouldUseNativePicker && { type: 'date' }),
               ...(enableCalendar && !shouldUseNativePicker && calendarTrigger === 'input'
-                ? { 'aria-haspopup': 'dialog', 'aria-expanded': open }
+                ? { 'aria-haspopup': 'dialog', 'aria-expanded': open, 'aria-controls': triggerAriaControls }
                 : {}),
             }}
           />

--- a/src/tedi/components/form/date-field/date-field.tsx
+++ b/src/tedi/components/form/date-field/date-field.tsx
@@ -651,8 +651,6 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
     if (shouldCloseOnSelect) setOpen(false);
   };
 
-  // Flag unparseable input on blur (kept visible) so the user gets feedback
-  // instead of the text silently failing to commit.
   const handleInputBlur = () => {
     if (inputValue.trim() === '') {
       setHasInvalidDateError(false);
@@ -720,10 +718,6 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
     useRole(context, { role: 'dialog' }),
   ]);
 
-  // Anchor the popover to the input element itself rather than the container
-  // `<div>` (which also holds the label), so an upward flip aligns to the input.
-  // In multiple mode (no single text input) fall back to the container reference —
-  // passing `null` would clear the anchor entirely and mis-position the popover.
   React.useEffect(() => {
     const anchorNode =
       mode === 'multiple'

--- a/src/tedi/components/form/date-field/date-field.tsx
+++ b/src/tedi/components/form/date-field/date-field.tsx
@@ -799,6 +799,13 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
 
   const triggerAriaControls = !useModalPicker ? (floatingAriaControls as string | undefined) : undefined;
 
+  const calendarTriggerProps: React.ButtonHTMLAttributes<HTMLButtonElement> = {
+    'aria-label': getLabel('dateField.openCalendar'),
+    'aria-expanded': useModalPicker ? modalOpen : open,
+    'aria-haspopup': 'dialog',
+    'aria-controls': triggerAriaControls,
+  };
+
   return (
     <>
       <div
@@ -816,16 +823,7 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
             values={formattedDatesWithIds.map((item) => item.label)}
             icon="calendar_today"
             onIconClick={openCalendar}
-            iconButtonProps={
-              enableCalendar
-                ? {
-                    'aria-label': getLabel('dateField.openCalendar'),
-                    'aria-expanded': useModalPicker ? modalOpen : open,
-                    'aria-haspopup': 'dialog',
-                    'aria-controls': triggerAriaControls,
-                  }
-                : undefined
-            }
+            iconButtonProps={enableCalendar ? calendarTriggerProps : undefined}
             isClearable
             required={required}
             onChange={(newLabels) => {
@@ -855,16 +853,7 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
             aria-expanded={enableCalendar && !shouldUseNativePicker ? open : undefined}
             isClearable
             onIconClick={openCalendar}
-            iconButtonProps={
-              enableCalendar && !shouldUseNativePicker
-                ? {
-                    'aria-label': getLabel('dateField.openCalendar'),
-                    'aria-expanded': useModalPicker ? modalOpen : open,
-                    'aria-haspopup': 'dialog',
-                    'aria-controls': triggerAriaControls,
-                  }
-                : undefined
-            }
+            iconButtonProps={enableCalendar && !shouldUseNativePicker ? calendarTriggerProps : undefined}
             onChange={(val) => (shouldUseNativePicker ? handleNativeInputChange(val) : handleInputChange(val))}
             onBlur={(e) => {
               if (!shouldUseNativePicker) handleInputBlur();

--- a/src/tedi/components/form/date-field/date-field.tsx
+++ b/src/tedi/components/form/date-field/date-field.tsx
@@ -799,8 +799,10 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
 
   const triggerAriaControls = !useModalPicker ? (floatingAriaControls as string | undefined) : undefined;
 
+  const openCalendarLabel = getLabel('dateField.openCalendar');
+
   const calendarTriggerProps: React.ButtonHTMLAttributes<HTMLButtonElement> = {
-    'aria-label': getLabel('dateField.openCalendar'),
+    'aria-label': openCalendarLabel,
     'aria-expanded': useModalPicker ? modalOpen : open,
     'aria-haspopup': 'dialog',
     'aria-controls': triggerAriaControls,
@@ -823,7 +825,7 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
             values={formattedDatesWithIds.map((item) => item.label)}
             icon="calendar_today"
             onIconClick={openCalendar}
-            iconButtonProps={enableCalendar ? calendarTriggerProps : undefined}
+            iconButtonProps={enableCalendar ? calendarTriggerProps : { 'aria-label': openCalendarLabel }}
             isClearable
             required={required}
             onChange={(newLabels) => {
@@ -850,10 +852,11 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
             value={shouldUseNativePicker ? nativeValue : inputValue}
             placeholder={placeholder}
             icon="calendar_today"
-            aria-expanded={enableCalendar && !shouldUseNativePicker ? open : undefined}
             isClearable
             onIconClick={openCalendar}
-            iconButtonProps={enableCalendar && !shouldUseNativePicker ? calendarTriggerProps : undefined}
+            iconButtonProps={
+              enableCalendar && !shouldUseNativePicker ? calendarTriggerProps : { 'aria-label': openCalendarLabel }
+            }
             onChange={(val) => (shouldUseNativePicker ? handleNativeInputChange(val) : handleInputChange(val))}
             onBlur={(e) => {
               if (!shouldUseNativePicker) handleInputBlur();
@@ -881,7 +884,12 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
               ...((inputProps as TextFieldProps)?.input as UnknownType),
               ...(shouldUseNativePicker && { type: 'date' }),
               ...(enableCalendar && !shouldUseNativePicker && calendarTrigger === 'input'
-                ? { 'aria-haspopup': 'dialog', 'aria-expanded': open, 'aria-controls': triggerAriaControls }
+                ? {
+                    role: 'combobox',
+                    'aria-haspopup': 'dialog',
+                    'aria-expanded': useModalPicker ? modalOpen : open,
+                    'aria-controls': triggerAriaControls,
+                  }
                 : {}),
             }}
           />

--- a/src/tedi/components/form/multi-value-field/multi-value-field.module.scss
+++ b/src/tedi/components/form/multi-value-field/multi-value-field.module.scss
@@ -13,6 +13,10 @@
   border-radius: var(--form-field-radius);
 }
 
+.tedi-multi-value-field__inner--row {
+  align-items: center;
+}
+
 .tedi-multi-value-field__input {
   flex: 1;
   min-width: 80px;
@@ -25,6 +29,21 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--layout-grid-gutters-04);
+}
+
+.tedi-multi-value-field__tags--row {
+  flex: 1;
+  flex-wrap: nowrap;
+  min-width: 0;
+  overflow: hidden;
+
+  > * {
+    flex-shrink: 0;
+  }
+}
+
+.tedi-multi-value-field__overflow-tag {
+  flex-shrink: 0;
 }
 
 .tedi-multi-value-field__right-area {

--- a/src/tedi/components/form/multi-value-field/multi-value-field.spec.tsx
+++ b/src/tedi/components/form/multi-value-field/multi-value-field.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import MultiValueField, { MultiValueFieldProps } from './multi-value-field';
 
@@ -20,6 +20,43 @@ describe('MultiValueField', () => {
 
     expect(screen.getByText('apple')).toBeInTheDocument();
     expect(screen.getByText('banana')).toBeInTheDocument();
+  });
+
+  it('renders every value tag in row layout when width cannot be measured', () => {
+    // jsdom reports 0 layout width, so the overflow measurement is skipped and
+    // all tags render — this guards the tagsDirection="row" plumbing/no-crash.
+    render(<MultiValueField {...defaultProps} tagsDirection="row" values={['apple', 'banana', 'cherry']} />);
+
+    expect(screen.getByText('apple')).toBeInTheDocument();
+    expect(screen.getByText('banana')).toBeInTheDocument();
+    expect(screen.getByText('cherry')).toBeInTheDocument();
+  });
+
+  describe('tagsDirection="row" overflow grouping', () => {
+    let originalClientWidth: PropertyDescriptor | undefined;
+    let originalOffsetWidth: PropertyDescriptor | undefined;
+
+    beforeAll(() => {
+      originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+      originalOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
+      Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 100 });
+      Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, value: 50 });
+    });
+
+    afterAll(() => {
+      if (originalClientWidth) Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
+      else delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientWidth;
+      if (originalOffsetWidth) Object.defineProperty(HTMLElement.prototype, 'offsetWidth', originalOffsetWidth);
+      else delete (HTMLElement.prototype as unknown as Record<string, unknown>).offsetWidth;
+    });
+
+    it('collapses overflowing tags into a +N counter', async () => {
+      render(<MultiValueField {...defaultProps} tagsDirection="row" values={['one', 'two', 'three']} />);
+
+      await waitFor(() => expect(screen.getByText('+2')).toBeInTheDocument());
+      expect(screen.getByText('one')).toBeInTheDocument();
+      expect(screen.queryByText('three')).not.toBeInTheDocument();
+    });
   });
 
   it('calls onChange when removing a value', () => {

--- a/src/tedi/components/form/multi-value-field/multi-value-field.spec.tsx
+++ b/src/tedi/components/form/multi-value-field/multi-value-field.spec.tsx
@@ -55,6 +55,37 @@ describe('MultiValueField', () => {
       expect(screen.getByText('one')).toBeInTheDocument();
       expect(screen.queryByText('three')).not.toBeInTheDocument();
     });
+
+    it('gives the overflow counter an accessible label', async () => {
+      const { container } = render(
+        <MultiValueField {...defaultProps} tagsDirection="row" values={['one', 'two', 'three']} />
+      );
+
+      await waitFor(() => expect(screen.getByText('+2')).toBeInTheDocument());
+      const counter = container.querySelector('.tedi-multi-value-field__overflow-tag');
+      expect(counter).toHaveAttribute('aria-label');
+      expect(counter?.getAttribute('aria-label')).toBeTruthy();
+    });
+
+    it('attaches the ResizeObserver once the tags container mounts (starting empty)', () => {
+      const observe = jest.fn();
+      class MockResizeObserver {
+        observe = observe;
+        unobserve = jest.fn();
+        disconnect = jest.fn();
+      }
+      const original = global.ResizeObserver;
+      global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+
+      try {
+        const { rerender } = render(<MultiValueField {...defaultProps} tagsDirection="row" values={[]} />);
+        expect(observe).not.toHaveBeenCalled();
+        rerender(<MultiValueField {...defaultProps} tagsDirection="row" values={['one', 'two']} />);
+        expect(observe).toHaveBeenCalledTimes(1);
+      } finally {
+        global.ResizeObserver = original;
+      }
+    });
   });
 
   it('calls onChange when removing a value', () => {

--- a/src/tedi/components/form/multi-value-field/multi-value-field.spec.tsx
+++ b/src/tedi/components/form/multi-value-field/multi-value-field.spec.tsx
@@ -57,14 +57,11 @@ describe('MultiValueField', () => {
     });
 
     it('gives the overflow counter an accessible label', async () => {
-      const { container } = render(
-        <MultiValueField {...defaultProps} tagsDirection="row" values={['one', 'two', 'three']} />
-      );
+      render(<MultiValueField {...defaultProps} tagsDirection="row" values={['one', 'two', 'three']} />);
 
-      await waitFor(() => expect(screen.getByText('+2')).toBeInTheDocument());
-      const counter = container.querySelector('.tedi-multi-value-field__overflow-tag');
-      expect(counter).toHaveAttribute('aria-label');
-      expect(counter?.getAttribute('aria-label')).toBeTruthy();
+      const counter = (await screen.findByText('+2')).closest('[role="status"]');
+      expect(counter).toHaveAccessibleName();
+      expect(counter).not.toHaveAccessibleName('+2');
     });
 
     it('attaches the ResizeObserver once the tags container mounts (starting empty)', () => {

--- a/src/tedi/components/form/multi-value-field/multi-value-field.spec.tsx
+++ b/src/tedi/components/form/multi-value-field/multi-value-field.spec.tsx
@@ -23,8 +23,6 @@ describe('MultiValueField', () => {
   });
 
   it('renders every value tag in row layout when width cannot be measured', () => {
-    // jsdom reports 0 layout width, so the overflow measurement is skipped and
-    // all tags render — this guards the tagsDirection="row" plumbing/no-crash.
     render(<MultiValueField {...defaultProps} tagsDirection="row" values={['apple', 'banana', 'cherry']} />);
 
     expect(screen.getByText('apple')).toBeInTheDocument();
@@ -103,8 +101,6 @@ describe('MultiValueField', () => {
 
   it('renders icon when provided', () => {
     render(<MultiValueField {...defaultProps} icon="add" />);
-
-    // Icon renders as span[data-name="icon"] in your setup
     expect(document.querySelector('[data-name="icon"]')).toBeInTheDocument();
   });
 

--- a/src/tedi/components/form/multi-value-field/multi-value-field.tsx
+++ b/src/tedi/components/form/multi-value-field/multi-value-field.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, { forwardRef, useState } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useLayoutEffect, useRef, useState } from 'react';
 
 import { useLabels } from '../../../providers/label-provider';
 import { Icon, IconWithoutBackgroundProps } from '../../base/icon/icon';
@@ -8,6 +8,11 @@ import Separator from '../../misc/separator/separator';
 import { Tag } from '../../tags/tag/tag';
 import FormLabel from '../form-label/form-label';
 import styles from './multi-value-field.module.scss';
+
+// Gap between tags (matches `--layout-grid-gutters-04`) and the width reserved
+// for the `+N` overflow counter when measuring how many tags fit on one row.
+const TAG_GAP_PX = 4;
+const COUNTER_RESERVE_PX = 44;
 
 export interface MultiValueFieldProps {
   /**
@@ -38,6 +43,14 @@ export interface MultiValueFieldProps {
    * @default 'primary'
    */
   tagColor?: 'primary' | 'secondary' | 'danger';
+  /**
+   * Layout for the value tags.
+   * - `'stack'` (default) — tags wrap onto multiple rows; the field grows in height.
+   * - `'row'` — tags stay on a single row; any that don't fit collapse into a
+   *   `+N` counter (the count is measured from the available width).
+   * @default stack
+   */
+  tagsDirection?: 'stack' | 'row';
   /**
    * Additional CSS class names applied to the root element.
    */
@@ -88,6 +101,7 @@ export const MultiValueField = forwardRef<MultiValueFieldRef, MultiValueFieldPro
     values: externalValues,
     onChange,
     tagColor = 'primary',
+    tagsDirection = 'stack',
     className,
     icon,
     onIconClick,
@@ -100,7 +114,75 @@ export const MultiValueField = forwardRef<MultiValueFieldRef, MultiValueFieldPro
   const { getLabel } = useLabels();
   const [internalValues, setInternalValues] = useState<string[]>(externalValues ?? []);
 
+  const innerRef = useRef<HTMLDivElement | null>(null);
+  const hiddenInputRef = useRef<HTMLInputElement | null>(null);
+
+  useImperativeHandle(ref, () => ({ input: hiddenInputRef.current, wrapper: innerRef.current }), []);
+
   const values = externalValues ?? internalValues;
+
+  const isRow = tagsDirection === 'row';
+  const tagsRef = useRef<HTMLDivElement | null>(null);
+  const lastMeasuredWidthRef = useRef(0);
+  const [visibleCount, setVisibleCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (isRow) setVisibleCount(null);
+  }, [values.length, isRow]);
+
+  useEffect(() => {
+    if (!isRow) return;
+    const el = tagsRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return undefined;
+
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width ?? 0;
+      if (width > 0 && width !== lastMeasuredWidthRef.current) setVisibleCount(null);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [isRow]);
+
+  useLayoutEffect(() => {
+    if (!isRow || visibleCount !== null) return;
+    const el = tagsRef.current;
+    if (!el) return;
+
+    const containerWidth = el.clientWidth;
+    if (containerWidth === 0) return;
+
+    const tagEls = el.querySelectorAll<HTMLElement>('[data-tedi-tag-index]');
+    if (tagEls.length === 0) return;
+
+    let totalWidth = 0;
+    for (let i = 0; i < tagEls.length; i++) {
+      totalWidth += tagEls[i].offsetWidth + (i > 0 ? TAG_GAP_PX : 0);
+    }
+    if (totalWidth <= containerWidth) {
+      lastMeasuredWidthRef.current = containerWidth;
+      setVisibleCount(tagEls.length);
+      return;
+    }
+
+    let usedWidth = 0;
+    let visible = 0;
+    for (let i = 0; i < tagEls.length; i++) {
+      const tagWidth = tagEls[i].offsetWidth;
+      const hasMore = i < tagEls.length - 1;
+      const reserved = hasMore ? COUNTER_RESERVE_PX + TAG_GAP_PX : 0;
+      const needed = usedWidth + tagWidth + (visible > 0 ? TAG_GAP_PX : 0);
+      if (needed + reserved <= containerWidth) {
+        usedWidth = needed;
+        visible++;
+      } else {
+        break;
+      }
+    }
+    if (visible === 0) visible = 1;
+
+    lastMeasuredWidthRef.current = containerWidth;
+    setVisibleCount(visible);
+  }, [isRow, visibleCount, values]);
 
   const updateValues = (newValues: string[]) => {
     setInternalValues(newValues);
@@ -117,6 +199,8 @@ export const MultiValueField = forwardRef<MultiValueFieldRef, MultiValueFieldPro
   const clearAll = () => {
     updateValues([]);
   };
+
+  const hiddenCount = isRow && visibleCount !== null ? Math.max(0, values.length - visibleCount) : 0;
 
   const renderIcon = () => {
     if (!icon) return null;
@@ -146,14 +230,37 @@ export const MultiValueField = forwardRef<MultiValueFieldRef, MultiValueFieldPro
   return (
     <div className={classNames(styles['tedi-multi-value-field'], className)}>
       {label && <FormLabel id={id} label={label} required={required} />}
-      <div className={styles['tedi-multi-value-field__inner']}>
+      <div
+        ref={innerRef}
+        className={classNames(styles['tedi-multi-value-field__inner'], {
+          [styles['tedi-multi-value-field__inner--row']]: isRow,
+        })}
+      >
         {values.length > 0 && (
-          <div className={styles['tedi-multi-value-field__tags']}>
-            {values.map((value, index) => (
-              <Tag key={`${value}-${index}`} color={tagColor} onClose={disabled ? undefined : () => removeValue(index)}>
-                {value}
+          <div
+            ref={tagsRef}
+            className={classNames(styles['tedi-multi-value-field__tags'], {
+              [styles['tedi-multi-value-field__tags--row']]: isRow,
+            })}
+          >
+            {values.map((value, index) => {
+              if (isRow && visibleCount !== null && index >= visibleCount) return null;
+              return (
+                <Tag
+                  key={`${value}-${index}`}
+                  color={tagColor}
+                  data-tedi-tag-index={index}
+                  onClose={disabled ? undefined : () => removeValue(index)}
+                >
+                  {value}
+                </Tag>
+              );
+            })}
+            {hiddenCount > 0 && (
+              <Tag color={tagColor} className={styles['tedi-multi-value-field__overflow-tag']}>
+                +{hiddenCount}
               </Tag>
-            ))}
+            )}
           </div>
         )}
 
@@ -175,6 +282,7 @@ export const MultiValueField = forwardRef<MultiValueFieldRef, MultiValueFieldPro
 
       {name && (
         <input
+          ref={hiddenInputRef}
           type="hidden"
           name={name}
           value={values.length ? JSON.stringify(values) : ''}

--- a/src/tedi/components/form/multi-value-field/multi-value-field.tsx
+++ b/src/tedi/components/form/multi-value-field/multi-value-field.tsx
@@ -1,5 +1,13 @@
 import classNames from 'classnames';
-import React, { forwardRef, useEffect, useImperativeHandle, useLayoutEffect, useRef, useState } from 'react';
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import { useLabels } from '../../../providers/label-provider';
 import { Icon, IconWithoutBackgroundProps } from '../../base/icon/icon';
@@ -122,7 +130,8 @@ export const MultiValueField = forwardRef<MultiValueFieldRef, MultiValueFieldPro
   const values = externalValues ?? internalValues;
 
   const isRow = tagsDirection === 'row';
-  const tagsRef = useRef<HTMLDivElement | null>(null);
+  const [tagsNode, setTagsNode] = useState<HTMLDivElement | null>(null);
+  const tagsRef = useCallback((node: HTMLDivElement | null) => setTagsNode(node), []);
   const lastMeasuredWidthRef = useRef(0);
   const [visibleCount, setVisibleCount] = useState<number | null>(null);
 
@@ -131,21 +140,19 @@ export const MultiValueField = forwardRef<MultiValueFieldRef, MultiValueFieldPro
   }, [values.length, isRow]);
 
   useEffect(() => {
-    if (!isRow) return;
-    const el = tagsRef.current;
-    if (!el || typeof ResizeObserver === 'undefined') return undefined;
+    if (!isRow || !tagsNode || typeof ResizeObserver === 'undefined') return undefined;
 
     const observer = new ResizeObserver((entries) => {
       const width = entries[0]?.contentRect.width ?? 0;
       if (width > 0 && width !== lastMeasuredWidthRef.current) setVisibleCount(null);
     });
-    observer.observe(el);
+    observer.observe(tagsNode);
     return () => observer.disconnect();
-  }, [isRow]);
+  }, [isRow, tagsNode]);
 
   useLayoutEffect(() => {
     if (!isRow || visibleCount !== null) return;
-    const el = tagsRef.current;
+    const el = tagsNode;
     if (!el) return;
 
     const containerWidth = el.clientWidth;
@@ -182,7 +189,7 @@ export const MultiValueField = forwardRef<MultiValueFieldRef, MultiValueFieldPro
 
     lastMeasuredWidthRef.current = containerWidth;
     setVisibleCount(visible);
-  }, [isRow, visibleCount, values]);
+  }, [isRow, visibleCount, values, tagsNode]);
 
   const updateValues = (newValues: string[]) => {
     setInternalValues(newValues);
@@ -257,7 +264,11 @@ export const MultiValueField = forwardRef<MultiValueFieldRef, MultiValueFieldPro
               );
             })}
             {hiddenCount > 0 && (
-              <Tag color={tagColor} className={styles['tedi-multi-value-field__overflow-tag']}>
+              <Tag
+                color={tagColor}
+                className={styles['tedi-multi-value-field__overflow-tag']}
+                aria-label={getLabel('multi-value-field.hidden-count', hiddenCount)}
+              >
                 +{hiddenCount}
               </Tag>
             )}

--- a/src/tedi/providers/label-provider/labels-map.ts
+++ b/src/tedi/providers/label-provider/labels-map.ts
@@ -496,6 +496,21 @@ export const labelsMap = validateDefaultLabels({
     en: 'Selected date is not available',
     ru: 'Выбранная дата недоступна',
   },
+  'dateField.invalidDateError': {
+    description:
+      'Inline error shown when the user types text that cannot be parsed into a valid date for the current mode.',
+    components: ['DateField', 'DateTimeField'],
+    et: 'Vigane kuupäev',
+    en: 'Invalid date',
+    ru: 'Неверная дата',
+  },
+  'dateField.openCalendar': {
+    description: 'Accessible name for the calendar toggle button in the DateField input.',
+    components: ['DateField', 'DateTimeField'],
+    et: 'Ava kalender',
+    en: 'Open calendar',
+    ru: 'Открыть календарь',
+  },
   'dateTimeField.timeHeading': {
     description: 'Heading rendered above the time picker in DateTimeField',
     components: ['DateTimeField'],

--- a/src/tedi/providers/label-provider/labels-map.ts
+++ b/src/tedi/providers/label-provider/labels-map.ts
@@ -100,6 +100,14 @@ export const labelsMap = validateDefaultLabels({
     en: 'Remove',
     ru: 'Удалить',
   },
+  'multi-value-field.hidden-count': {
+    description:
+      'Accessible label for the overflow counter shown in single-row (`tagsDirection="row"`) mode, announcing how many selected values are hidden.',
+    components: ['MultiValueField', 'DateField'],
+    et: (count: number) => `Veel ${count}`,
+    en: (count: number) => `${count} more`,
+    ru: (count: number) => `Ещё ${count}`,
+  },
   cancel: {
     description: 'For canceling an action',
     components: ['TableFilter'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added row and stacked layouts for multiple date selections.
  * Row layout keeps tags on one line and groups hidden selections into a `+N` indicator.
  * Added validation messaging and configurable error text for manually entered invalid dates.
  * Added accessible labeling and calendar popup associations for the calendar toggle.

* **Bug Fixes**
  * Invalid-date errors now clear when users edit the input.
  * Improved calendar positioning for multiple-date fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->