### PR TITLE
fix(community): add typescript annotations and missing tags to deprecated community components #563

### DIFF
--- a/skills/tedi-react/references/components.md
+++ b/skills/tedi-react/references/components.md
@@ -1769,10 +1769,10 @@ Import from `@tedi-design-system/react/community`. These are community-contribut
 - `openItem?: string[]`, `onToggleItem?: (id: string) => void`, `gutter?: VerticalSpacingSize`
 - Sub-components: AccordionItem, AccordionItemHeader, AccordionItemContent
 
-### Card
+### Card — **DEPRECATED** (use TEDI-Ready Card)
 
 - `border?: CardBorderType`, `borderless?: boolean`, `padding?: number`, `background?: CardBackground`
-- Sub-components: Card.Header, Card.Content, Card.Notification
+- Sub-components: Card.Header, Card.Content, Card.Notification (all deprecated — use the TEDI-Ready equivalents)
 
 ## Buttons
 
@@ -1786,22 +1786,22 @@ Import from `@tedi-design-system/react/community`. These are community-contribut
 
 ### Radio — **DEPRECATED** (use TEDI-Ready Radio via ChoiceGroup)
 
-### Select
+### Select — **DEPRECATED** (use TEDI-Ready Select)
 
 - `id: string`, `options`, `value?`, `defaultValue?`, `onChange?`
 - `multiple?: boolean`, `async?: boolean`, `isSearchable?: boolean`, `isClearable?: boolean`
 
-### Toggle
+### Toggle — **DEPRECATED** (use TEDI-Ready Toggle)
 
 - `ariaLabel: string`, `label?`, `checked?`, `defaultChecked?`, `onChange?`
 - `size?: 'medium' | 'large'`, `color?: 'default' | 'alternative'`, `icon?`, `disabled?`
 
-### ChoiceGroup
+### ChoiceGroup — **DEPRECATED** (use TEDI-Ready ChoiceGroup)
 
 - `id: string`, `items: ChoiceGroupItemProps[]`, `inputType?: 'radio' | 'checkbox'`
 - `type?: 'light' | 'selector' | 'filter' | 'default'`, `value?`, `onChange?`
 
-### FileUpload
+### FileUpload — **DEPRECATED** (use TEDI-Ready FileUpload)
 
 - `id: string`, `name: string`, `accept?`, `multiple?`, `maxSize?`
 - `files?`, `defaultFiles?`, `onChange?`, `onDelete?`
@@ -1817,18 +1817,18 @@ Import from `@tedi-design-system/react/community`. These are community-contribut
 - `fieldOptions: TextFieldProps | SelectProps | DateTimePickerProps`
 - `content: ReactNode`
 
-### DateTimePicker
+### DateTimePicker — **DEPRECATED** (use TEDI-Ready DateTimeField)
 
 - Date/time picker using MUI x-date-pickers
 
 ## Navigation
 
-### Stepper
+### Stepper — **DEPRECATED** (use TEDI-Ready HorizontalStepper)
 
 - `activeStep?`, `defaultActiveStep?: number`, `onActiveStepChange?`
 - `allowStepLabelClick?: boolean`, `ariaLabel: string`, `card?: CardProps | boolean`
 
-### Tabs
+### Tabs — **DEPRECATED** (use TEDI-Ready Tabs)
 
 - `currentTab?: string`, `defaultCurrentTab?`, `onTabChange?`
 - Sub-components: Tabs.Nav, Tabs.NavItem, Tabs.Item
@@ -1842,7 +1842,7 @@ Import from `@tedi-design-system/react/community`. These are community-contribut
 
 ### Dropdown — **DEPRECATED** (use TEDI-Ready Dropdown)
 
-### Modal
+### Modal — **DEPRECATED** (use TEDI-Ready Modal)
 
 - `size?: 12 | 10 | 8 | 6`, `position?: 'center' | 'right' | 'bottom'`
 - `lockScroll?: boolean`, `trapFocus?: boolean`, `returnFocus?: boolean`
@@ -1858,14 +1858,14 @@ Import from `@tedi-design-system/react/community`. These are community-contribut
 
 ### Tag — **DEPRECATED** (use TEDI-Ready Tag)
 
-### Status
+### Status — **DEPRECATED** (use TEDI-Ready StatusIndicator)
 
 - `type: 'error' | 'success' | 'inactive' | 'warning'`
 - `tooltipContent?: ReactNode`
 
 ## Table
 
-### Table (TanStack React Table wrapper)
+### Table (TanStack React Table wrapper) — **DEPRECATED** (use TEDI-Ready Table)
 
 - `data: TData[]`, `columns: ColumnDef[]`
 - `pagination?`, `sorting?`, `rowSelection?`, `columnPinning?`
@@ -1879,10 +1879,14 @@ Import from `@tedi-design-system/react/community`. These are community-contribut
 
 ## Layout
 
-### Header
+### Header — **DEPRECATED** (use TEDI-Ready Header)
 
 - Sub-components: HeaderContent, HeaderActions, HeaderNavigation, HeaderLanguage, HeaderRole, HeaderSettings, HeaderNotifications, HeaderLogo
-- **Note:** The TEDI-Ready Header is now available with a different sub-component API. Prefer the TEDI-Ready version for new work.
+- **Note:** The TEDI-Ready Header is available with a different sub-component API. `HeaderLanguage` and `HeaderRole` are deprecated too — prefer the TEDI-Ready equivalents.
+
+### SideNav — **DEPRECATED** (use TEDI-Ready SideNav)
+
+- Sub-components: SideNavItem (also `SidenavToggle`, deprecated — use the TEDI-Ready equivalents)
 
 ### Footer — **DEPRECATED** (use TEDI-Ready Footer)
 
@@ -1890,7 +1894,7 @@ Data-driven legacy footer (`categories` array + `logo` + `bottomElement`). Respo
 
 ## Misc
 
-### Placeholder (empty state)
+### Placeholder (empty state) — **DEPRECATED** (use TEDI-Ready EmptyState)
 
 - `icon?: string | IconProps | ReactNode`, `cardProps?`, `isNested?: boolean`
 
@@ -1903,7 +1907,7 @@ Data-driven legacy footer (`categories` array + `logo` + `bottomElement`). Respo
 
 - `children: ReactNode`, `onItemOpen: (index: number) => void`
 
-### ToggleOpen
+### ToggleOpen — **DEPRECATED** (use TEDI-Ready CollapseButton)
 
 - `openText: string`, `closeText: string`, `isOpen: boolean`
 

--- a/src/community/components/anchor/anchor.tsx
+++ b/src/community/components/anchor/anchor.tsx
@@ -52,6 +52,7 @@ InternalAnchor.displayName = 'Anchor';
  * Inherits all props from the component passed into `as`. If `as` is omitted, then the default is native `<a>` tag
  *
  * To allow Customized Anchor usage as direct children of Header you need to add displayName to it. <a href="/docs/components-layout-header-header-overview--header-overview#settings">See more.</a>
+ * @deprecated Use `Link` from `@tedi-design-system/react/tedi` instead.
  */
 
 // TODO: Remove ts-ignore

--- a/src/community/components/button/button.tsx
+++ b/src/community/components/button/button.tsx
@@ -82,6 +82,7 @@ InternalButton.displayName = 'Button';
 
 /**
  * Renders a `<button>` tag and has all of its props plus our own defined props. For more info about usage of buttons see [Button](/docs/documentation-buttons-buttons--buttons) & [ButtonGroups](/docs/documentation-buttons-buttongroups--buttongroups) documentation.
+ * @deprecated Use `Button` from `@tedi-design-system/react/tedi` instead.
  */
 // TODO: Remove ts-ignore
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/community/components/card/card-content/card-content.tsx
+++ b/src/community/components/card/card-content/card-content.tsx
@@ -46,6 +46,9 @@ export interface CardContentProps extends BreakpointSupport<CardContentBreakpoin
   children?: React.ReactNode;
 }
 
+/**
+ * @deprecated Use `CardContent` from `@tedi-design-system/react/tedi` instead.
+ */
 export const CardContent = (props: CardContentProps): JSX.Element => {
   const { padding: rootPadding, background: rootBackground } = React.useContext(CardContext);
   const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);

--- a/src/community/components/card/card-header/card-header.tsx
+++ b/src/community/components/card/card-header/card-header.tsx
@@ -48,6 +48,9 @@ export interface CardHeaderAsButton extends Partial<React.ButtonHTMLAttributes<H
   role: 'button';
 }
 
+/**
+ * @deprecated Use `CardHeader` from `@tedi-design-system/react/tedi` instead.
+ */
 export const CardHeader = (props: CardHeaderProps): JSX.Element => {
   const { variant, ...restOfProps } = props;
   const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);

--- a/src/community/components/card/card-notification/card-notification.tsx
+++ b/src/community/components/card/card-notification/card-notification.tsx
@@ -6,6 +6,9 @@ import style from './card-notification.module.scss';
 
 export type CardNotificationProps = AlertProps & Pick<CardContentProps, 'padding'>;
 
+/**
+ * @deprecated Use `CardNotification` from `@tedi-design-system/react/tedi` instead.
+ */
 export const CardNotification = (props: CardNotificationProps): JSX.Element => {
   const { children, padding, className, ...rest } = props;
 

--- a/src/community/components/card/card.tsx
+++ b/src/community/components/card/card.tsx
@@ -43,6 +43,9 @@ export interface CardProps extends BreakpointSupport<CardBreakpointProps> {
     | React.ReactNode;
 }
 
+/**
+ * @deprecated Use `Card` from `@tedi-design-system/react/tedi` instead.
+ */
 export const Card = forwardRef<HTMLDivElement, CardProps>((props, ref): JSX.Element => {
   const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {

--- a/src/community/components/dropdown/dropdown.tsx
+++ b/src/community/components/dropdown/dropdown.tsx
@@ -62,6 +62,9 @@ export type DropdownProps = {
   focusManager?: Omit<React.ComponentProps<typeof FloatingFocusManager>, 'context' | 'children'>;
 };
 
+/**
+ * @deprecated Use `Dropdown` from `@tedi-design-system/react/tedi` instead.
+ */
 export const Dropdown = (props: DropdownProps) => {
   const { getLabel } = useLabels();
   const { button, items, onItemClick, closeMenuOnClick = true, ...rest } = props;

--- a/src/community/components/form/choice-group/choice-group.stories.tsx
+++ b/src/community/components/form/choice-group/choice-group.stories.tsx
@@ -13,6 +13,11 @@ import { ChoiceGroupItemProps } from './choice-group.types';
 const meta: Meta<typeof ChoiceGroup> = {
   component: ChoiceGroup,
   title: 'Community/Form/ChoiceGroup',
+  parameters: {
+    status: {
+      type: ['deprecated', 'ExistsInTediReady'],
+    },
+  },
 };
 
 export default meta;

--- a/src/community/components/form/choice-group/choice-group.tsx
+++ b/src/community/components/form/choice-group/choice-group.tsx
@@ -91,6 +91,9 @@ export interface ChoiceGroupProps extends FormLabelProps {
   >;
 }
 
+/**
+ * @deprecated Use `ChoiceGroup` from `@tedi-design-system/react/tedi` instead.
+ */
 export const ChoiceGroup = (props: ChoiceGroupProps): React.ReactElement => {
   const { getLabel } = useLabels();
   const {

--- a/src/community/components/form/file-upload/file-upload.stories.tsx
+++ b/src/community/components/form/file-upload/file-upload.stories.tsx
@@ -6,6 +6,11 @@ import FileUpload from './file-upload';
 const meta: Meta<typeof FileUpload> = {
   component: FileUpload,
   title: 'Community/Form/FileUpload',
+  parameters: {
+    status: {
+      type: ['deprecated', 'ExistsInTediReady'],
+    },
+  },
 };
 
 export default meta;

--- a/src/community/components/form/file-upload/file-upload.tsx
+++ b/src/community/components/form/file-upload/file-upload.tsx
@@ -113,6 +113,9 @@ const getUploadErrorHelperText = (rejectedFiles: RejectedFile[], getLabel: ILabe
     .join('. ');
 };
 
+/**
+ * @deprecated Use `FileUpload` from `@tedi-design-system/react/tedi` instead.
+ */
 export const FileUpload = (props: FileUploadProps): JSX.Element => {
   const { getLabel } = useLabels();
   const {

--- a/src/community/components/form/radio/radio.tsx
+++ b/src/community/components/form/radio/radio.tsx
@@ -9,6 +9,9 @@ import styles from './radio.module.scss';
 
 export type RadioProps = ChoiceInputProps;
 
+/**
+ * @deprecated Use `Radio` from `@tedi-design-system/react/tedi` instead.
+ */
 export const Radio = (props: RadioProps): JSX.Element => {
   const {
     id,

--- a/src/community/components/form/select/select.tsx
+++ b/src/community/components/form/select/select.tsx
@@ -300,6 +300,9 @@ export type TSelectValue<CustomData = unknown> =
   | ReadonlyArray<ISelectOption<CustomData>>
   | null;
 
+/**
+ * @deprecated Use `Select` from `@tedi-design-system/react/tedi` instead.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const Select = forwardRef<SelectInstance<ISelectOption, boolean, IGroupedOptions<ISelectOption>>, SelectProps>(
   (props, ref): JSX.Element => {

--- a/src/community/components/form/toggle/toggle.tsx
+++ b/src/community/components/form/toggle/toggle.tsx
@@ -70,6 +70,9 @@ export interface ToggleProps {
   isLoading?: boolean;
 }
 
+/**
+ * @deprecated Use `Toggle` from `@tedi-design-system/react/tedi` instead.
+ */
 export const Toggle = forwardRef<HTMLButtonElement, ToggleProps>((props, ref) => {
   const {
     ariaLabel,

--- a/src/community/components/layout/header/components/header-language/header-language.stories.tsx
+++ b/src/community/components/layout/header/components/header-language/header-language.stories.tsx
@@ -10,6 +10,11 @@ positioned. <br />
 const meta: Meta<typeof HeaderLanguage> = {
   component: HeaderLanguage,
   title: 'Community/Layout/Header/HeaderLanguage',
+  parameters: {
+    status: {
+      type: ['deprecated', 'ExistsInTediReady'],
+    },
+  },
 };
 
 export default meta;

--- a/src/community/components/layout/header/components/header-language/header-language.tsx
+++ b/src/community/components/layout/header/components/header-language/header-language.tsx
@@ -26,6 +26,9 @@ export interface HeaderLanguageProps {
   languages?: Language[];
 }
 
+/**
+ * @deprecated Use `HeaderLanguage` from `@tedi-design-system/react/tedi` instead.
+ */
 export const HeaderLanguage: React.FC<HeaderLanguageProps> = (props) => {
   const { languages } = props;
   const isDesktopTablet = useLayout(['desktop', 'tablet']);

--- a/src/community/components/layout/header/components/header-role/header-role.stories.tsx
+++ b/src/community/components/layout/header/components/header-role/header-role.stories.tsx
@@ -12,6 +12,11 @@ import RoleSelection from './header-role';
 const meta: Meta<typeof RoleSelection> = {
   component: RoleSelection,
   title: 'Community/Layout/Header/HeaderRole',
+  parameters: {
+    status: {
+      type: ['deprecated', 'ExistsInTediReady'],
+    },
+  },
 };
 
 export default meta;

--- a/src/community/components/layout/header/components/header-role/header-role.tsx
+++ b/src/community/components/layout/header/components/header-role/header-role.tsx
@@ -34,6 +34,9 @@ export interface HeaderRoleProps {
   renderModal?: boolean;
 }
 
+/**
+ * @deprecated Use `HeaderRole` from `@tedi-design-system/react/tedi` instead.
+ */
 export const HeaderRole: React.FC<HeaderRoleProps> = (props) => {
   const { renderModal = false, ...rest } = props;
   const [isOpen, setIsOpen] = React.useState(false);

--- a/src/community/components/layout/header/components/sidenav-toggle/sidenav-toggle.tsx
+++ b/src/community/components/layout/header/components/sidenav-toggle/sidenav-toggle.tsx
@@ -6,6 +6,9 @@ import Button from '../../../../button/button';
 import { LayoutContext } from '../../../layout-context';
 import styles from './sidenav-toggle.module.scss';
 
+/**
+ * @deprecated Use `SidenavToggle` from `@tedi-design-system/react/tedi` instead.
+ */
 export const SidenavToggle = () => {
   const { menuOpen, toggleMenu, reference, getReferenceProps, sideNavProps, onHeaderSidenavToggle } =
     React.useContext(LayoutContext);

--- a/src/community/components/layout/header/header/header.tsx
+++ b/src/community/components/layout/header/header/header.tsx
@@ -69,6 +69,9 @@ export interface HeaderProps<H extends React.ElementType> {
   notification?: HeaderNotificationProps;
 }
 
+/**
+ * @deprecated Use `Header` from `@tedi-design-system/react/tedi` instead.
+ */
 export const Header = <H extends React.ElementType = 'a'>(props: HeaderProps<H>) => {
   const {
     skipLinks,

--- a/src/community/components/layout/sidenav/sidenav.stories.tsx
+++ b/src/community/components/layout/sidenav/sidenav.stories.tsx
@@ -7,6 +7,9 @@ const meta: Meta<typeof Sidenav> = {
   title: 'Community/Layout/Sidenav',
   parameters: {
     layout: 'fullscreen',
+    status: {
+      type: ['deprecated', 'ExistsInTediReady'],
+    },
   },
 };
 

--- a/src/community/components/layout/sidenav/sidenav.tsx
+++ b/src/community/components/layout/sidenav/sidenav.tsx
@@ -79,6 +79,9 @@ export type SideNavItem<C extends React.ElementType = 'a'> = AnchorProps<C> & {
 // tiny helper to defer closing to the next frame (prevents ghost click on touch)
 const defer = (fn: () => void) => requestAnimationFrame(fn);
 
+/**
+ * @deprecated Use `SideNav` from `@tedi-design-system/react/tedi` instead.
+ */
 export const SideNav = <C extends React.ElementType = 'a'>(props: SideNavProps<C>) => {
   const {
     navItems,

--- a/src/community/components/status/status.stories.tsx
+++ b/src/community/components/status/status.stories.tsx
@@ -5,6 +5,11 @@ import Status from './status';
 const meta: Meta<typeof Status> = {
   component: Status,
   title: 'Community/Status',
+  parameters: {
+    status: {
+      type: ['deprecated', 'ExistsInTediReady'],
+    },
+  },
 };
 
 export default meta;

--- a/src/community/components/status/status.tsx
+++ b/src/community/components/status/status.tsx
@@ -22,6 +22,9 @@ export interface StatusProps {
   tooltipContent?: React.ReactNode;
 }
 
+/**
+ * @deprecated Use `StatusIndicator` from `@tedi-design-system/react/tedi` instead.
+ */
 export const Status = (props: StatusProps): JSX.Element => {
   const { children, type, className, tooltipContent, ...rest } = props;
   const StatusBEM = cn(styles['status'], className, styles[`status--${type}`]);

--- a/src/community/components/table/table.tsx
+++ b/src/community/components/table/table.tsx
@@ -40,6 +40,9 @@ import { TableContext } from './table-context';
 export const PAGE_SIZE_WITHOUT_PAGINATION = 10000;
 const emptyData: IntentionalAny[] = [];
 
+/**
+ * @deprecated Use `Table` from `@tedi-design-system/react/tedi` instead.
+ */
 export function Table<TData extends DefaultTData<TData>>(props: TableProps<TData>): JSX.Element {
   const { getLabel } = useLabels();
   const {

--- a/src/community/components/tag/tag.tsx
+++ b/src/community/components/tag/tag.tsx
@@ -72,6 +72,9 @@ export interface TagProps {
   id?: string;
 }
 
+/**
+ * @deprecated Use `Tag` from `@tedi-design-system/react/tedi` instead.
+ */
 export const Tag = forwardRef<HTMLDivElement, TagProps>((props, ref): JSX.Element => {
   const {
     children,

--- a/src/community/components/toggle-open/toggle-open.stories.tsx
+++ b/src/community/components/toggle-open/toggle-open.stories.tsx
@@ -9,6 +9,11 @@ import ToggleOpen from './toggle-open';
 const meta: Meta<typeof ToggleOpen> = {
   component: ToggleOpen,
   title: 'Community/ToggleOpen',
+  parameters: {
+    status: {
+      type: ['deprecated', 'ExistsInTediReady'],
+    },
+  },
 };
 
 export default meta;

--- a/src/community/components/toggle-open/toggle-open.tsx
+++ b/src/community/components/toggle-open/toggle-open.tsx
@@ -25,6 +25,9 @@ export interface ToggleOpenProps extends Omit<ButtonProps, 'children' | 'iconRig
   iconRight?: Partial<IconProps>;
 }
 
+/**
+ * @deprecated Use `CollapseButton` from `@tedi-design-system/react/tedi` instead.
+ */
 export const ToggleOpen = ({ openText, closeText, isOpen, iconRight, ...rest }: ToggleOpenProps): JSX.Element => {
   const ToggleOpenBEM = cn(
     { [styles['toggle--open']]: isOpen },

--- a/src/community/components/tooltip/tooltip-trigger.tsx
+++ b/src/community/components/tooltip/tooltip-trigger.tsx
@@ -14,6 +14,9 @@ export interface TooltipTriggerProps {
   children: JSX.Element;
 }
 
+/**
+ * @deprecated Use `TooltipTrigger` from `@tedi-design-system/react/tedi` instead.
+ */
 export const TooltipTrigger = (props: TooltipTriggerProps): JSX.Element => {
   const { children } = props;
   const { getLabel } = useLabels();

--- a/src/community/components/tooltip/tooltip.tsx
+++ b/src/community/components/tooltip/tooltip.tsx
@@ -30,6 +30,9 @@ export interface TooltipProps {
   maxWidth?: 'none' | 'small' | 'medium' | 'large';
 }
 
+/**
+ * @deprecated Use `Tooltip` from `@tedi-design-system/react/tedi` instead.
+ */
 export const Tooltip = (props: TooltipProps): JSX.Element | null => {
   const { children, maxWidth = 'medium', cardProps, className } = props;
   const { open, x, y, strategy, focusManager, floating, arrowRef, getFloatingProps, placement, context } =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked legacy Community components as deprecated and identified their TEDI-Ready replacements.
  * Expanded migration guidance for cards, forms, navigation, layout, status, tables, overlays, and utility components.
  * Storybook entries now visibly label applicable components as deprecated and available in TEDI-Ready.
  * No component behavior or runtime functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->