### PR TITLE
fix(label): move tooltip out of native label element #729

### DIFF
--- a/src/tedi/components/content/label/label.module.scss
+++ b/src/tedi/components/content/label/label.module.scss
@@ -28,3 +28,8 @@
     margin-left: var(--layout-grid-gutters-08);
   }
 }
+
+.tedi-label__wrapper {
+  display: inline-flex;
+  align-items: center;
+}

--- a/src/tedi/components/content/label/label.spec.tsx
+++ b/src/tedi/components/content/label/label.spec.tsx
@@ -92,6 +92,24 @@ describe('Label component', () => {
     expect(screen.getByRole('tooltip')).toBeInTheDocument();
   });
 
+  it('accepts rich (non-string) tooltip content', () => {
+    render(
+      <Label
+        tooltip={
+          <>
+            <strong>Bold</strong> and a <a href="#more">link</a>
+          </>
+        }
+      >
+        Label
+      </Label>
+    );
+
+    fireEvent.mouseEnter(screen.getByRole('button'));
+    expect(screen.getByText('Bold').tagName).toBe('STRONG');
+    expect(screen.getByRole('link', { name: 'link' })).toBeInTheDocument();
+  });
+
   it('renders the tooltip trigger outside the label element', () => {
     render(
       <Label tooltip="This is a tooltip" htmlFor="field">

--- a/src/tedi/components/content/label/label.spec.tsx
+++ b/src/tedi/components/content/label/label.spec.tsx
@@ -84,12 +84,26 @@ describe('Label component', () => {
   it('renders an InfoButton when tooltip is provided', () => {
     render(<Label tooltip="This is a tooltip">Label</Label>);
 
-    const infoButton = screen.getByRole('button', { hidden: true });
+    const infoButton = screen.getByRole('button');
     expect(infoButton).toBeInTheDocument();
 
     fireEvent.mouseEnter(infoButton);
 
     expect(screen.getByRole('tooltip')).toBeInTheDocument();
+  });
+
+  it('renders the tooltip trigger outside the label element', () => {
+    render(
+      <Label tooltip="This is a tooltip" htmlFor="field">
+        Label
+      </Label>
+    );
+
+    const labelElement = screen.getByText('Label').closest('label');
+    const infoButton = screen.getByRole('button');
+
+    expect(labelElement).toBeInTheDocument();
+    expect(labelElement).not.toContainElement(infoButton);
   });
 
   it('does not render InfoButton if tooltip is not provided', () => {

--- a/src/tedi/components/content/label/label.stories.tsx
+++ b/src/tedi/components/content/label/label.stories.tsx
@@ -33,7 +33,7 @@ export const Default: Story = {
   render: Template,
 
   args: {
-    children: 'Active ingredient',
+    children: 'Toimeaine',
   },
 };
 
@@ -42,7 +42,7 @@ export const Required: Story = {
   name: 'Required field',
 
   args: {
-    children: 'Active ingredient',
+    children: 'Toimeaine',
     required: true,
   },
 };
@@ -52,7 +52,7 @@ export const DefaultBold: Story = {
   name: 'Bold',
 
   args: {
-    children: 'Active ingredient',
+    children: 'Toimeaine',
     isBold: true,
   },
 };
@@ -62,7 +62,7 @@ export const RequiredBold: Story = {
   name: 'Bold Required field',
 
   args: {
-    children: 'Active ingredient',
+    children: 'Toimeaine',
     required: true,
     isBold: true,
   },
@@ -72,9 +72,9 @@ export const InfoButtonStory: Story = {
   render: Template,
 
   args: {
-    children: 'Active ingredient',
+    children: 'Toimeaine',
     required: true,
-    tooltip: 'More Info',
+    tooltip: 'Lisainfo',
   },
 };
 
@@ -82,7 +82,7 @@ export const DefaultSmall: Story = {
   render: Template,
 
   args: {
-    children: 'Active ingredient',
+    children: 'Toimeaine',
     isSmall: true,
   },
 };
@@ -91,7 +91,7 @@ export const DefaultSmallBold: Story = {
   render: Template,
 
   args: {
-    children: 'Active ingredient',
+    children: 'Toimeaine',
     isBold: true,
     isSmall: true,
   },

--- a/src/tedi/components/content/label/label.tsx
+++ b/src/tedi/components/content/label/label.tsx
@@ -64,7 +64,7 @@ export const Label = forwardRef<HTMLLabelElement | HTMLSpanElement, LabelProps>(
     className
   );
 
-  return (
+  const labelElement = (
     <Element ref={ref} className={labelBEM} {...rest}>
       {children}
       {required && (
@@ -72,17 +72,25 @@ export const Label = forwardRef<HTMLLabelElement | HTMLSpanElement, LabelProps>(
           *
         </span>
       )}
-      {tooltip && (
-        <span aria-hidden="true" className={styles['tedi-label__info']}>
-          <Tooltip>
-            <Tooltip.Trigger>
-              <InfoButton isSmall={isSmall} aria-label={getLabel('infoButton.moreInformation')} />
-            </Tooltip.Trigger>
-            <Tooltip.Content>{tooltip}</Tooltip.Content>
-          </Tooltip>
-        </span>
-      )}
     </Element>
+  );
+
+  if (!tooltip) {
+    return labelElement;
+  }
+
+  return (
+    <span className={styles['tedi-label__wrapper']}>
+      {labelElement}
+      <span className={styles['tedi-label__info']}>
+        <Tooltip>
+          <Tooltip.Trigger>
+            <InfoButton isSmall={isSmall} aria-label={getLabel('infoButton.moreInformation')} />
+          </Tooltip.Trigger>
+          <Tooltip.Content>{tooltip}</Tooltip.Content>
+        </Tooltip>
+      </span>
+    </span>
   );
 });
 

--- a/src/tedi/components/content/label/label.tsx
+++ b/src/tedi/components/content/label/label.tsx
@@ -1,10 +1,8 @@
 import cn from 'classnames';
-import { ElementType, forwardRef, LabelHTMLAttributes } from 'react';
+import { ElementType, forwardRef, LabelHTMLAttributes, ReactNode } from 'react';
 
 import { BreakpointSupport, useBreakpointProps } from '../../../helpers';
-import { useLabels } from '../../../providers/label-provider';
-import InfoButton from '../../buttons/info-button/info-button';
-import Tooltip from '../../overlays/tooltip/tooltip';
+import { InfoTooltip } from '../../overlays/tooltip/info-tooltip';
 import styles from './label.module.scss';
 
 type LabelBreakpointProps = {
@@ -37,10 +35,11 @@ export interface LabelProps
    */
   required?: boolean;
   /**
-   * Tooltip content to display when hovering over the info button.
+   * Tooltip content to display when hovering over the info button. Accepts rich
+   * content (e.g. bold text, links), not just a plain string.
    * If provided, an info button with a tooltip will be rendered.
    */
-  tooltip?: string;
+  tooltip?: ReactNode;
 }
 
 export const Label = forwardRef<HTMLLabelElement | HTMLSpanElement, LabelProps>((props, ref) => {
@@ -55,7 +54,6 @@ export const Label = forwardRef<HTMLLabelElement | HTMLSpanElement, LabelProps>(
     tooltip,
     ...rest
   } = getCurrentBreakpointProps<LabelProps>(props);
-  const { getLabel } = useLabels();
 
   const labelBEM = cn(
     styles['tedi-label'],
@@ -83,12 +81,7 @@ export const Label = forwardRef<HTMLLabelElement | HTMLSpanElement, LabelProps>(
     <span className={styles['tedi-label__wrapper']}>
       {labelElement}
       <span className={styles['tedi-label__info']}>
-        <Tooltip>
-          <Tooltip.Trigger>
-            <InfoButton isSmall={isSmall} aria-label={getLabel('infoButton.moreInformation')} />
-          </Tooltip.Trigger>
-          <Tooltip.Content>{tooltip}</Tooltip.Content>
-        </Tooltip>
+        <InfoTooltip isSmall={isSmall}>{tooltip}</InfoTooltip>
       </span>
     </span>
   );

--- a/src/tedi/components/form/choice-input.types.ts
+++ b/src/tedi/components/form/choice-input.types.ts
@@ -50,9 +50,10 @@ export interface ChoiceInputProps {
    */
   hover?: boolean;
   /**
-   * Provide content for tooltip.
+   * Provide content for tooltip. Accepts rich content (e.g. bold text, links),
+   * not just a plain string.
    */
-  tooltip?: string;
+  tooltip?: React.ReactNode;
   /**
    *  Input size
    */

--- a/src/tedi/components/form/form-label/form-label.tsx
+++ b/src/tedi/components/form/form-label/form-label.tsx
@@ -44,7 +44,7 @@ export interface FormLabelProps {
    * Tooltip content to display when hovering over the info button.
    * If provided, an info button with a tooltip will be rendered.
    */
-  tooltip?: string;
+  tooltip?: React.ReactNode;
 }
 
 export const FormLabel = forwardRef<HTMLLabelElement, FormLabelProps>(

--- a/src/tedi/components/overlays/tooltip/index.ts
+++ b/src/tedi/components/overlays/tooltip/index.ts
@@ -1,3 +1,4 @@
 export * from './tooltip';
 export * from './tooltip-content';
 export * from './tooltip-trigger';
+export * from './info-tooltip';

--- a/src/tedi/components/overlays/tooltip/info-tooltip.spec.tsx
+++ b/src/tedi/components/overlays/tooltip/info-tooltip.spec.tsx
@@ -1,10 +1,23 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
+import { useBreakpointProps } from '../../../helpers';
 import { InfoTooltip } from './info-tooltip';
 
 import '@testing-library/jest-dom';
 
+jest.mock('../../../helpers', () => ({
+  ...jest.requireActual('../../../helpers'),
+  useBreakpointProps: jest.fn(),
+}));
+
 describe('InfoTooltip', () => {
+  beforeEach(() => {
+    (useBreakpointProps as jest.Mock).mockReturnValue({
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars, @typescript-eslint/no-explicit-any
+      getCurrentBreakpointProps: ({ sm, md, lg, xl, xxl, defaultServerBreakpoint, ...xs }: any) => xs,
+    });
+  });
+
   it('renders an info button with an accessible name and no visible tooltip initially', () => {
     render(<InfoTooltip>Helpful hint</InfoTooltip>);
 
@@ -23,5 +36,21 @@ describe('InfoTooltip', () => {
     render(<InfoTooltip ariaLabel="What is this?">Helpful hint</InfoTooltip>);
 
     expect(screen.getByRole('button')).toHaveAccessibleName('What is this?');
+  });
+
+  it('resolves per-breakpoint overrides (e.g. ariaLabel at md)', () => {
+    // Simulate md being the active breakpoint: md props win over the xs base.
+    (useBreakpointProps as jest.Mock).mockReturnValue({
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars, @typescript-eslint/no-explicit-any
+      getCurrentBreakpointProps: ({ sm, md, lg, xl, xxl, defaultServerBreakpoint, ...xs }: any) => ({ ...xs, ...md }),
+    });
+
+    render(
+      <InfoTooltip ariaLabel="Mobile label" md={{ ariaLabel: 'Desktop label' }}>
+        Helpful hint
+      </InfoTooltip>
+    );
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('Desktop label');
   });
 });

--- a/src/tedi/components/overlays/tooltip/info-tooltip.spec.tsx
+++ b/src/tedi/components/overlays/tooltip/info-tooltip.spec.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { InfoTooltip } from './info-tooltip';
+
+import '@testing-library/jest-dom';
+
+describe('InfoTooltip', () => {
+  it('renders an info button with an accessible name and no visible tooltip initially', () => {
+    render(<InfoTooltip>Helpful hint</InfoTooltip>);
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('infoButton.moreInformation');
+    expect(screen.queryByText('Helpful hint')).not.toBeInTheDocument();
+  });
+
+  it('shows the tooltip content on hover', () => {
+    render(<InfoTooltip>Helpful hint</InfoTooltip>);
+
+    fireEvent.mouseEnter(screen.getByRole('button'));
+    expect(screen.getByText('Helpful hint')).toBeInTheDocument();
+  });
+
+  it('uses a custom ariaLabel for the trigger', () => {
+    render(<InfoTooltip ariaLabel="What is this?">Helpful hint</InfoTooltip>);
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('What is this?');
+  });
+});

--- a/src/tedi/components/overlays/tooltip/info-tooltip.stories.tsx
+++ b/src/tedi/components/overlays/tooltip/info-tooltip.stories.tsx
@@ -11,7 +11,10 @@ const meta: Meta<typeof InfoTooltip> = {
   title: 'TEDI-Ready/Components/Overlay/InfoTooltip',
   parameters: {
     status: {
-      type: ['devComponent'],
+      type: [
+        'devComponent',
+        { name: 'breakpointSupport', url: '?path=/docs/helpers-usebreakpointprops--usebreakpointprops' },
+      ],
     },
   },
 };

--- a/src/tedi/components/overlays/tooltip/info-tooltip.stories.tsx
+++ b/src/tedi/components/overlays/tooltip/info-tooltip.stories.tsx
@@ -1,0 +1,39 @@
+import { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Label } from '../../content/label/label';
+import { InfoTooltip } from './info-tooltip';
+
+/**
+ * `InfoTooltip` is the standard "ⓘ + tooltip" pattern — an `InfoButton` that reveals a `Tooltip` on hover/focus.
+ */
+const meta: Meta<typeof InfoTooltip> = {
+  component: InfoTooltip,
+  title: 'TEDI-Ready/Components/Overlay/InfoTooltip',
+  parameters: {
+    status: {
+      type: ['devComponent'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof InfoTooltip>;
+
+export const Default: Story = {
+  args: {
+    children: 'Lisainfo väljal',
+  },
+};
+
+/**
+ * Typical usage — a trailing info affix next to a form label. `Label` renders
+ * this exact pattern via its `tooltip` prop (it uses `InfoTooltip` internally and
+ * places the trigger outside the `<label>`), so you rarely compose it by hand.
+ */
+export const InLabelRow: Story = {
+  render: () => (
+    <Label htmlFor="city" required tooltip="Sisestage linn, kus te praegu elate.">
+      Linn
+    </Label>
+  ),
+};

--- a/src/tedi/components/overlays/tooltip/info-tooltip.tsx
+++ b/src/tedi/components/overlays/tooltip/info-tooltip.tsx
@@ -1,13 +1,14 @@
 import { Placement } from '@floating-ui/react';
 import { ReactNode } from 'react';
 
+import { BreakpointSupport, useBreakpointProps } from '../../../helpers';
 import { useLabels } from '../../../providers/label-provider';
 import InfoButton from '../../buttons/info-button/info-button';
 import { OverlayOpenWith } from '../overlay/overlay';
 import Tooltip from './tooltip';
 import { TooltipContentProps } from './tooltip-content';
 
-export interface InfoTooltipProps {
+interface InfoTooltipBreakpointProps {
   /**
    * Tooltip content shown when the info button is hovered or focused.
    */
@@ -44,21 +45,25 @@ export interface InfoTooltipProps {
   ariaLabel?: string;
 }
 
+export type InfoTooltipProps = BreakpointSupport<InfoTooltipBreakpointProps>;
+
 /**
  * An info button that reveals a tooltip on hover/focus — the standard
  * "ⓘ + tooltip" pattern. Bundles `InfoButton` + `Tooltip` so consumers don't
  * have to wire the trigger and content by hand (e.g. next to a form label).
  */
-export const InfoTooltip = ({
-  children,
-  placement,
-  openWith,
-  maxWidth,
-  color = 'default',
-  isSmall = false,
-  ariaLabel,
-}: InfoTooltipProps): JSX.Element => {
+export const InfoTooltip = (props: InfoTooltipProps): JSX.Element => {
   const { getLabel } = useLabels();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
+  const {
+    children,
+    placement,
+    openWith,
+    maxWidth,
+    color = 'default',
+    isSmall = false,
+    ariaLabel,
+  } = getCurrentBreakpointProps<InfoTooltipBreakpointProps>(props);
 
   return (
     <Tooltip placement={placement} openWith={openWith}>

--- a/src/tedi/components/overlays/tooltip/info-tooltip.tsx
+++ b/src/tedi/components/overlays/tooltip/info-tooltip.tsx
@@ -1,0 +1,75 @@
+import { Placement } from '@floating-ui/react';
+import { ReactNode } from 'react';
+
+import { useLabels } from '../../../providers/label-provider';
+import InfoButton from '../../buttons/info-button/info-button';
+import { OverlayOpenWith } from '../overlay/overlay';
+import Tooltip from './tooltip';
+import { TooltipContentProps } from './tooltip-content';
+
+export interface InfoTooltipProps {
+  /**
+   * Tooltip content shown when the info button is hovered or focused.
+   */
+  children: ReactNode;
+  /**
+   * Placement of the tooltip relative to the info button.
+   * @default top
+   */
+  placement?: Placement;
+  /**
+   * How the tooltip is opened.
+   * @default hover
+   */
+  openWith?: OverlayOpenWith;
+  /**
+   * Max width of the tooltip content.
+   * @default medium
+   */
+  maxWidth?: TooltipContentProps['maxWidth'];
+  /**
+   * Info button colour. Use `inverted` on dark or coloured backgrounds.
+   * @default default
+   */
+  color?: 'default' | 'inverted';
+  /**
+   * Renders the smaller (16px) info button.
+   * @default false
+   */
+  isSmall?: boolean;
+  /**
+   * Accessible name for the info button.
+   * @default the translated "more information" label
+   */
+  ariaLabel?: string;
+}
+
+/**
+ * An info button that reveals a tooltip on hover/focus — the standard
+ * "ⓘ + tooltip" pattern. Bundles `InfoButton` + `Tooltip` so consumers don't
+ * have to wire the trigger and content by hand (e.g. next to a form label).
+ */
+export const InfoTooltip = ({
+  children,
+  placement,
+  openWith,
+  maxWidth,
+  color = 'default',
+  isSmall = false,
+  ariaLabel,
+}: InfoTooltipProps): JSX.Element => {
+  const { getLabel } = useLabels();
+
+  return (
+    <Tooltip placement={placement} openWith={openWith}>
+      <Tooltip.Trigger>
+        <InfoButton color={color} isSmall={isSmall} aria-label={ariaLabel ?? getLabel('infoButton.moreInformation')} />
+      </Tooltip.Trigger>
+      <Tooltip.Content maxWidth={maxWidth}>{children}</Tooltip.Content>
+    </Tooltip>
+  );
+};
+
+InfoTooltip.displayName = 'InfoTooltip';
+
+export default InfoTooltip;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `InfoTooltip` component with rich content, responsive configuration, and accessible labeling options.
  * Labels and choice inputs now support rich tooltip content beyond plain text.
* **Bug Fixes**
  * Improved label layout and vertical alignment for tooltip triggers.
  * Updated tooltip rendering and placement to preserve accessibility and label associations.
* **Tests**
  * Expanded coverage for rich tooltip content, hover interactions, accessibility, and label associations.
* **Documentation**
  * Added tooltip examples and updated label stories with localized text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->