### PR TITLE
fix(search): stop using placeholder as Search region name #57

### DIFF
--- a/src/tedi/components/form/search/search.spec.tsx
+++ b/src/tedi/components/form/search/search.spec.tsx
@@ -37,6 +37,11 @@ describe('Search component', () => {
     expect(screen.getByRole('search')).toHaveAttribute('aria-label', 'Search products');
   });
 
+  it('falls back to the generic label when ariaLabel is an empty string', () => {
+    render(<Search {...defaultProps} ariaLabel="" />);
+    expect(screen.getByRole('search')).toHaveAttribute('aria-label', 'search');
+  });
+
   it('calls onSearch when the search button is clicked', () => {
     render(<Search {...defaultProps} button={{ children: 'Search' }} />);
     const button = screen.getByRole('button', { name: /search/i });

--- a/src/tedi/components/form/search/search.spec.tsx
+++ b/src/tedi/components/form/search/search.spec.tsx
@@ -25,6 +25,18 @@ describe('Search component', () => {
     expect(input).toBeInTheDocument();
   });
 
+  it('does not name the search region with the placeholder (avoids double announcement)', () => {
+    render(<Search {...defaultProps} placeholder="Search by name or keyword" />);
+    const region = screen.getByRole('search');
+    expect(region).toHaveAttribute('aria-label', 'search');
+    expect(region.getAttribute('aria-label')).not.toBe('Search by name or keyword');
+  });
+
+  it('uses the provided ariaLabel as the search region name', () => {
+    render(<Search {...defaultProps} ariaLabel="Search products" />);
+    expect(screen.getByRole('search')).toHaveAttribute('aria-label', 'Search products');
+  });
+
   it('calls onSearch when the search button is clicked', () => {
     render(<Search {...defaultProps} button={{ children: 'Search' }} />);
     const button = screen.getByRole('button', { name: /search/i });

--- a/src/tedi/components/form/search/search.tsx
+++ b/src/tedi/components/form/search/search.tsx
@@ -73,8 +73,11 @@ export const Search = forwardRef<TextFieldForwardRef, SearchProps>(
       ...(button ? {} : { icon: resolvedSearchIcon }),
     };
 
-    const defaultAriaLabel = placeholder || getLabel('search');
-    const searchAriaLabel = ariaLabel ?? defaultAriaLabel;
+    // Name the search landmark with the generic "search" label rather than the
+    // placeholder. The input already surfaces the placeholder, so reusing it as
+    // the region name makes screen readers announce it twice. Consumers should
+    // set `ariaLabel` to give the region a distinct name (e.g. "Search products").
+    const searchAriaLabel = ariaLabel ?? getLabel('search');
 
     return (
       <div

--- a/src/tedi/components/form/search/search.tsx
+++ b/src/tedi/components/form/search/search.tsx
@@ -77,7 +77,9 @@ export const Search = forwardRef<TextFieldForwardRef, SearchProps>(
     // placeholder. The input already surfaces the placeholder, so reusing it as
     // the region name makes screen readers announce it twice. Consumers should
     // set `ariaLabel` to give the region a distinct name (e.g. "Search products").
-    const searchAriaLabel = ariaLabel ?? getLabel('search');
+    // `||` (not `??`) so an empty-string `ariaLabel` also falls back — otherwise
+    // the landmark would render with an empty accessible name.
+    const searchAriaLabel = ariaLabel || getLabel('search');
 
     return (
       <div


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen reader behavior for the Search component by preventing placeholder text from being announced as the search region label.
  * Search regions now use a consistent default accessible label.
  * Custom accessible labels are correctly applied when provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->