### PR TITLE
feat(calendar): add dayStatus, fullWidth props, ability to make month/year picker static #632

### DIFF
--- a/skills/tedi-react/references/components.md
+++ b/skills/tedi-react/references/components.md
@@ -428,7 +428,8 @@ Sub-component: `List.Item`
 - `selectionLevel?: 'days' | 'months' | 'years' = 'days'` — coarser commit level: `'years'` selects Jan 1 of the picked year, `'months'` selects day 1
 - `disabledMatchers?: Matcher[]` — same shape as DayPicker's `disabled`
 - `availableDays?: Date[] | ((date) => boolean)`, `unavailableDays?: Date[] | ((date) => boolean)` — overlay highlights without disabling neighbours
-- `monthYearSelectType?: 'dropdown' | 'grid' = 'dropdown'` — header picker style
+- `monthYearSelectType?: 'dropdown' | 'grid' | 'static' = 'dropdown'` — header picker style; `'static'` makes the month/year a plain non-clickable label (only prev/next nav changes the month — disables month/year selection)
+- `dayStatus?: (date: Date) => { type: StatusIndicatorType; label: string } | null | undefined` — per-day status; return a `{ type, label }` to overlay a `StatusIndicator` dot on that day (the `label` is folded into the day's `aria-label`; the dot itself is `aria-hidden`)
 - `showOutsideDays?: boolean = true`, `showNavigation?: boolean = true`
 - `locale?: Locale = et`, `localeCode?: string = 'et-EE'`
 - `required?: boolean`, `footer?: ReactNode`, `className?: string`
@@ -747,7 +748,8 @@ Same as Checkbox (without indeterminate)
 - `initialMonth?: Date`
 - `closeOnSelect?: boolean` — default: `true` for `'single'`, `false` otherwise
 - `footer?: ReactNode` — slot below the calendar grid
-- `monthYearSelectType?: 'dropdown' | 'grid' = 'dropdown'` — header pickers
+- `monthYearSelectType?: 'dropdown' | 'grid' | 'static' = 'dropdown'` — header pickers; `'static'` renders the month/year as a plain non-clickable label (only prev/next nav changes the month — disables month/year selection)
+- `dayStatus?: (date: Date) => { type: StatusIndicatorType; label: string } | null | undefined` — per-day status forwarded to the calendar; overlays a `StatusIndicator` dot on matching days (label folded into the day's `aria-label`)
 - `showNavigation?: boolean = true` — show/hide the header prev/next nav; when hidden the month/year header also becomes a static (non-clickable) label, locking the calendar to the visible month(s) — a clean "pick from these" view
 - `selectionLevel?: 'days' | 'months' | 'years' = 'days'` — coarser commit level
 - `initialView?: 'days' | 'months' | 'years' = selectionLevel` — grid the calendar opens on, independent of `selectionLevel`; e.g. `initialView="years"` with default `selectionLevel="days"` opens the year grid and drills year → month → day (pair with `monthYearSelectType="grid"`)

--- a/skills/tedi-react/references/forms.md
+++ b/skills/tedi-react/references/forms.md
@@ -167,6 +167,17 @@ const [date, setDate] = useState<Date>();
 <DateField id="year" label="Year" selectionLevel="years" />
 ```
 
+**Static header** — `monthYearSelectType="static"` renders the month/year as a plain, non-clickable label so users can only move via the prev/next nav (disables the month/year jump pickers). `'dropdown'` (default) and `'grid'` are the interactive options.
+
+**Per-day status** — `dayStatus` overlays a `StatusIndicator` dot on matching days (e.g. availability). Return `{ type, label }` per day (or `null`); the `label` is folded into the day's `aria-label` since the dot is decorative:
+```tsx
+<DateField
+  id="appointments"
+  label="Appointment"
+  dayStatus={(date) => (isBooked(date) ? { type: 'error', label: 'Fully booked' } : null)}
+/>
+```
+
 **Forwarding to the inner input** — pass-through props (e.g. `helper`, `icon`, `isClearable`):
 ```tsx
 <DateField

--- a/src/tedi/components/content/calendar/calendar.module.scss
+++ b/src/tedi/components/content/calendar/calendar.module.scss
@@ -22,6 +22,52 @@
     border-radius: 0;
   }
 
+  &--full-width {
+    width: 100%;
+
+    .tedi-calendar__month {
+      flex: 1 1 0;
+      min-width: 0;
+    }
+
+    .tedi-calendar__weekday,
+    .tedi-calendar__week-number,
+    .tedi-calendar__day {
+      width: auto;
+      height: auto;
+    }
+
+    .tedi-calendar__day button,
+    .tedi-calendar__weekday-inner {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      min-width: var(--form-calendar-date-width);
+      height: auto;
+      min-height: var(--form-calendar-date-width);
+      aspect-ratio: 1 / 1;
+      margin: 0;
+    }
+
+    .tedi-calendar__today button {
+      position: relative;
+      border: none;
+
+      &::before {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: var(--form-calendar-date-width);
+        height: var(--form-calendar-date-width);
+        content: '';
+        border: var(--tedi-borders-01) solid var(--form-datepicker-today-border);
+        border-radius: 50%;
+        transform: translate(-50%, -50%);
+      }
+    }
+  }
+
   table {
     width: 100%;
     border-spacing: 0;
@@ -71,11 +117,11 @@
 
     button {
       all: unset;
+      position: relative;
       display: block;
       width: 100%;
       width: var(--form-calendar-date-width);
       height: var(--form-calendar-date-width);
-      overflow: hidden;
       font-size: var(--body-regular-size);
       font-weight: var(--tedi-weight-02);
       color: var(--general-text-primary);
@@ -97,6 +143,13 @@
       cursor: auto;
       background: unset;
     }
+  }
+
+  &__day-status {
+    position: absolute;
+    top: var(--tedi-borders-02);
+    right: 0;
+    pointer-events: none;
   }
 
   &__today {
@@ -210,6 +263,11 @@
     background: none;
     border: none;
     border-radius: 0;
+  }
+
+  &.tedi-calendar--full-width {
+    width: 100%;
+    max-width: none;
   }
 }
 

--- a/src/tedi/components/content/calendar/calendar.module.scss
+++ b/src/tedi/components/content/calendar/calendar.module.scss
@@ -56,14 +56,10 @@
 
       &::before {
         position: absolute;
-        top: 50%;
-        left: 50%;
-        width: var(--form-calendar-date-width);
-        height: var(--form-calendar-date-width);
+        inset: 0;
         content: '';
         border: var(--tedi-borders-01) solid var(--form-datepicker-today-border);
         border-radius: 50%;
-        transform: translate(-50%, -50%);
       }
     }
   }

--- a/src/tedi/components/content/calendar/calendar.module.scss
+++ b/src/tedi/components/content/calendar/calendar.module.scss
@@ -13,6 +13,7 @@
 .tedi-calendar {
   width: fit-content;
   max-width: none;
+  background: var(--card-background-primary);
   border: var(--tedi-borders-01) solid var(--card-border-primary);
   border-radius: var(--card-radius-rounded);
 
@@ -129,7 +130,7 @@
       }
     }
 
-    &:hover:not(.tedi-calendar__disabled) {
+    &:hover:not(.tedi-calendar__disabled, .tedi-calendar__day--selected) {
       color: var(--general-text-primary);
       cursor: pointer;
       background-color: var(--form-datepicker-date-hover);

--- a/src/tedi/components/content/calendar/calendar.spec.tsx
+++ b/src/tedi/components/content/calendar/calendar.spec.tsx
@@ -8,6 +8,7 @@ import '@testing-library/jest-dom';
 const mockDayPickerProps: { current: any } = { current: null };
 
 jest.mock('react-day-picker', () => ({
+  ...jest.requireActual('react-day-picker'),
   DayPicker: (props: any) => {
     mockDayPickerProps.current = props;
     const MonthCaption = props.components?.MonthCaption;
@@ -189,6 +190,18 @@ describe('Calendar', () => {
     expect(dayPicker).toHaveClass('custom-class');
   });
 
+  it('does not apply the full-width modifier by default', () => {
+    render(<Calendar {...baseProps} />);
+
+    expect(screen.getByTestId('day-picker')).not.toHaveClass('tedi-calendar--full-width');
+  });
+
+  it('applies the full-width modifier class when fullWidth is set', () => {
+    render(<Calendar {...baseProps} fullWidth />);
+
+    expect(screen.getByTestId('day-picker')).toHaveClass('tedi-calendar--full-width');
+  });
+
   it('applies disabled matchers when provided', () => {
     const disabledMatchers = [(date: Date) => true];
 
@@ -330,6 +343,44 @@ describe('Calendar', () => {
 
       expect(mockDayPickerProps.current.mode).toBe('single');
       expect(mockDayPickerProps.current.selected).toBeUndefined();
+    });
+  });
+
+  describe('dayStatus', () => {
+    const dayStatus = (date: Date) => (date.getDate() === 15 ? { type: 'success' as const, label: 'Available' } : null);
+
+    it('does not register a custom DayButton when dayStatus is omitted', () => {
+      render(<Calendar {...baseProps} />);
+
+      expect(mockDayPickerProps.current.components.DayButton).toBeUndefined();
+    });
+
+    it('overlays a StatusIndicator and appends the status label to aria-label for matching days', () => {
+      render(<Calendar {...baseProps} dayStatus={dayStatus} />);
+
+      const DayButton = mockDayPickerProps.current.components.DayButton;
+      const { container } = render(
+        <DayButton day={{ date: new Date(2025, 0, 15) }} modifiers={{}} aria-label="15 January 2025">
+          15
+        </DayButton>
+      );
+
+      expect(container.querySelector('[data-name="status-indicator"]')).toBeInTheDocument();
+      expect(container.querySelector('button')).toHaveAttribute('aria-label', '15 January 2025, Available');
+    });
+
+    it('renders a plain day button without an indicator for days that have no status', () => {
+      render(<Calendar {...baseProps} dayStatus={dayStatus} />);
+
+      const DayButton = mockDayPickerProps.current.components.DayButton;
+      const { container } = render(
+        <DayButton day={{ date: new Date(2025, 0, 16) }} modifiers={{}} aria-label="16 January 2025">
+          16
+        </DayButton>
+      );
+
+      expect(container.querySelector('[data-name="status-indicator"]')).not.toBeInTheDocument();
+      expect(container.querySelector('button')).toHaveAttribute('aria-label', '16 January 2025');
     });
   });
 

--- a/src/tedi/components/content/calendar/calendar.spec.tsx
+++ b/src/tedi/components/content/calendar/calendar.spec.tsx
@@ -1,9 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { fireEvent, render, screen } from '@testing-library/react';
 
+import { useBreakpointProps } from '../../../helpers';
 import { Calendar, CalendarProps } from './calendar';
 
 import '@testing-library/jest-dom';
+
+jest.mock('../../../helpers', () => ({
+  ...jest.requireActual('../../../helpers'),
+  useBreakpointProps: jest.fn(),
+}));
 
 const mockDayPickerProps: { current: any } = { current: null };
 
@@ -58,6 +64,13 @@ describe('Calendar', () => {
     handleSelect: jest.fn(),
     applyValue: jest.fn(),
   };
+
+  beforeEach(() => {
+    (useBreakpointProps as jest.Mock).mockReturnValue({
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
+      getCurrentBreakpointProps: ({ sm, md, lg, xl, xxl, defaultServerBreakpoint, ...xs }: any) => xs,
+    });
+  });
 
   it('renders DayPicker in default (days) view', () => {
     render(<Calendar {...baseProps} />);
@@ -198,6 +211,17 @@ describe('Calendar', () => {
 
   it('applies the full-width modifier class when fullWidth is set', () => {
     render(<Calendar {...baseProps} fullWidth />);
+
+    expect(screen.getByTestId('day-picker')).toHaveClass('tedi-calendar--full-width');
+  });
+
+  it('resolves per-breakpoint overrides (e.g. fullWidth at md)', () => {
+    (useBreakpointProps as jest.Mock).mockReturnValue({
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
+      getCurrentBreakpointProps: ({ sm, md, lg, xl, xxl, defaultServerBreakpoint, ...xs }: any) => ({ ...xs, ...md }),
+    });
+
+    render(<Calendar {...baseProps} fullWidth={false} md={{ fullWidth: true }} />);
 
     expect(screen.getByTestId('day-picker')).toHaveClass('tedi-calendar--full-width');
   });

--- a/src/tedi/components/content/calendar/calendar.stories.tsx
+++ b/src/tedi/components/content/calendar/calendar.stories.tsx
@@ -2,10 +2,12 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { et } from 'react-day-picker/locale';
 
+import { Text } from '../../base/typography/text/text';
 import Button from '../../buttons/button/button';
 import { CalendarView } from '../../form/date-field/date-field';
 import { Col, Row } from '../../layout/grid';
 import { VerticalSpacing } from '../../layout/vertical-spacing';
+import { StatusIndicator } from '../../tags/status-indicator';
 import { Calendar, CalendarProps } from './calendar';
 
 /**
@@ -268,6 +270,84 @@ export const WithWeeksCount: Story = {
       <CalendarTemplate showWeekNumber numberOfMonths={2} />
     </VerticalSpacing>
   ),
+};
+
+/**
+ * Set `fullWidth` and wrap the calendar in a sized container — it fills that
+ * width and scales its cells (and rows) to match. The container's width drives
+ * the size.
+ */
+export const FullWidthSizes: Story = {
+  render: () => {
+    const sizes = [
+      { label: 'Medium — 480px', width: 480 },
+      { label: 'Large — 640px', width: 640 },
+      { label: 'Extra large — 800px', width: 800 },
+    ];
+
+    return (
+      <VerticalSpacing size={2}>
+        {sizes.map(({ label, width }) => (
+          <VerticalSpacing size={0.5} key={width}>
+            <Text color="secondary" modifiers="small">
+              {label}
+            </Text>
+            <div style={{ width: '100%', maxWidth: `${width}px` }}>
+              <CalendarTemplate fullWidth monthYearSelectType="static" showNavigation={false} />
+            </div>
+          </VerticalSpacing>
+        ))}
+      </VerticalSpacing>
+    );
+  },
+};
+
+/**
+ * Set `monthYearSelectType="static"` to disable month/year selection: the header
+ * shows the month and year as a plain, non-clickable label. The user can only
+ * change the month via the prev/next navigation buttons — there is no dropdown
+ * or drill-down grid.
+ */
+export const StaticMonthYear: Story = {
+  render: () => <CalendarTemplate monthYearSelectType="static" />,
+};
+
+/**
+ * Pass a `dayStatus` function `(date) => { type, label }` to overlay a
+ * `StatusIndicator` dot on specific days. The `label` is folded into the day
+ * button's `aria-label` so screen readers announce the status alongside the date
+ * (the dot itself stays `aria-hidden`, satisfying WCAG 1.1.1). Pair the calendar
+ * with a legend in the footer so colourblind users can decode the indicator
+ * colours (WCAG 1.4.1 — colour is not the only cue).
+ */
+export const WithDayStatus: Story = {
+  render: () => {
+    const today = new Date();
+    const day = (offset: number) => new Date(today.getFullYear(), today.getMonth(), today.getDate() + offset);
+
+    const statusByDate = new Map(
+      [day(-2), day(4), day(10)].map((date) => [date.toDateString(), 'Confirmed appointment'])
+    );
+
+    const dayStatus: CalendarProps['dayStatus'] = (date) => {
+      const label = statusByDate.get(date.toDateString());
+      return label ? { type: 'success', label } : null;
+    };
+
+    return (
+      <CalendarTemplate
+        dayStatus={dayStatus}
+        footer={
+          <Row>
+            <Col width="auto" className="flex align-items-center gap-2">
+              <StatusIndicator type="success" size="sm" hasBorder />
+              Confirmed
+            </Col>
+          </Row>
+        }
+      />
+    );
+  },
 };
 
 export const MonthView: Story = {

--- a/src/tedi/components/content/calendar/calendar.stories.tsx
+++ b/src/tedi/components/content/calendar/calendar.stories.tsx
@@ -75,7 +75,7 @@ export const WithFooter: Story = {
               <Row>
                 <Col width={12} className="text-center">
                   <Button visualType="link" size="small" iconRight="schedule">
-                    Select time
+                    Vali kellaaeg
                   </Button>
                 </Col>
               </Row>
@@ -87,7 +87,7 @@ export const WithFooter: Story = {
             footer={
               <Row>
                 <Col width={12} className="text-center">
-                  <Button iconRight="arrow_forward">Search times</Button>
+                  <Button iconRight="arrow_forward">Otsi aegu</Button>
                 </Col>
               </Row>
             }
@@ -101,7 +101,7 @@ export const WithFooter: Story = {
               <Row>
                 <Col width={12} className="text-center">
                   <Button visualType="secondary" size="small">
-                    Cancel selection
+                    Tühista valik
                   </Button>
                 </Col>
               </Row>
@@ -115,10 +115,10 @@ export const WithFooter: Story = {
                 <Col width={12}>
                   <div className="flex gap-3">
                     <Button visualType="secondary" fullWidth size="small">
-                      Cancel
+                      Tühista
                     </Button>
                     <Button visualType="primary" fullWidth size="small">
-                      Save
+                      Salvesta
                     </Button>
                   </div>
                 </Col>
@@ -163,7 +163,7 @@ export const WithLegend: Story = {
                       borderRadius: '4px',
                     }}
                   ></div>{' '}
-                  Selected
+                  Valitud
                 </Col>
                 <Col width="auto" className="flex align-items-center gap-2">
                   <div
@@ -175,7 +175,7 @@ export const WithLegend: Story = {
                       borderRadius: '4px',
                     }}
                   ></div>{' '}
-                  Available
+                  Saadaval
                 </Col>
               </Row>
             }
@@ -243,14 +243,22 @@ export const Range: Story = {
       from: today,
       to: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 12),
     };
+    // Two-month range with `showOutsideDays={false}` so the second month has one
+    // clean start/end instead of the range restarting on its leading outside days.
+    const rangeAcrossMonths = {
+      from: new Date(2026, 6, 24),
+      to: new Date(2026, 7, 6),
+    };
 
     return (
       <VerticalSpacing>
         <CalendarTemplate mode="range" value={defaultRange} handleSelect={(d) => console.log('Range selected:', d)} />
         <CalendarTemplate
           mode="range"
-          value={defaultRange}
+          value={rangeAcrossMonths}
+          currentMonth={new Date(2026, 6, 1)}
           numberOfMonths={2}
+          showOutsideDays={false}
           handleSelect={(d) => console.log('Range selected:', d)}
           showNavigation={false}
         />
@@ -273,9 +281,7 @@ export const WithWeeksCount: Story = {
 };
 
 /**
- * Set `fullWidth` and wrap the calendar in a sized container — it fills that
- * width and scales its cells (and rows) to match. The container's width drives
- * the size.
+ * `fullWidth` fills the parent container, scaling cells to match its width.
  */
 export const FullWidthSizes: Story = {
   render: () => {
@@ -303,22 +309,17 @@ export const FullWidthSizes: Story = {
 };
 
 /**
- * Set `monthYearSelectType="static"` to disable month/year selection: the header
- * shows the month and year as a plain, non-clickable label. The user can only
- * change the month via the prev/next navigation buttons — there is no dropdown
- * or drill-down grid.
+ * `monthYearSelectType="static"` shows the month/year as a plain label — only
+ * the prev/next buttons change the month.
  */
 export const StaticMonthYear: Story = {
   render: () => <CalendarTemplate monthYearSelectType="static" />,
 };
 
 /**
- * Pass a `dayStatus` function `(date) => { type, label }` to overlay a
- * `StatusIndicator` dot on specific days. The `label` is folded into the day
- * button's `aria-label` so screen readers announce the status alongside the date
- * (the dot itself stays `aria-hidden`, satisfying WCAG 1.1.1). Pair the calendar
- * with a legend in the footer so colourblind users can decode the indicator
- * colours (WCAG 1.4.1 — colour is not the only cue).
+ * `dayStatus: (date) => { type, label }` overlays a `StatusIndicator` dot on a
+ * day; the `label` is added to its `aria-label`. Pair with a footer legend so
+ * colour isn't the only cue.
  */
 export const WithDayStatus: Story = {
   render: () => {

--- a/src/tedi/components/content/calendar/calendar.stories.tsx
+++ b/src/tedi/components/content/calendar/calendar.stories.tsx
@@ -19,6 +19,12 @@ import { Calendar, CalendarProps } from './calendar';
 const meta: Meta<typeof Calendar> = {
   title: 'TEDI-Ready/Content/Calendar',
   component: Calendar,
+  parameters: {
+    status: {
+      type: [{ name: 'breakpointSupport', url: '?path=/docs/helpers-usebreakpointprops--usebreakpointprops' }],
+    },
+    controls: { exclude: ['sm', 'md', 'lg', 'xl', 'xxl'] },
+  },
 };
 
 export default meta;

--- a/src/tedi/components/content/calendar/calendar.stories.tsx
+++ b/src/tedi/components/content/calendar/calendar.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { et } from 'react-day-picker/locale';
 
 import { Text } from '../../base/typography/text/text';
@@ -24,6 +24,7 @@ const meta: Meta<typeof Calendar> = {
       type: [{ name: 'breakpointSupport', url: '?path=/docs/helpers-usebreakpointprops--usebreakpointprops' }],
     },
     controls: { exclude: ['sm', 'md', 'lg', 'xl', 'xxl'] },
+
     a11y: {
       config: {
         rules: [{ id: 'color-contrast', enabled: false }],
@@ -43,6 +44,13 @@ const CalendarTemplate: React.FC<Partial<CalendarProps>> = (props) => {
   const defaultValue = props.mode === 'multiple' ? [] : props.mode === 'range' ? { from: new Date() } : undefined;
 
   const [value, setValue] = useState(props.value ?? defaultValue);
+
+  const prevMode = useRef(props.mode);
+  useEffect(() => {
+    if (prevMode.current === props.mode) return;
+    prevMode.current = props.mode;
+    setValue(props.mode === 'multiple' ? [] : props.mode === 'range' ? { from: new Date() } : undefined);
+  }, [props.mode]);
 
   const handleSelect: CalendarProps['handleSelect'] = (selected, day, modifiers, event) => {
     setValue(selected);
@@ -73,7 +81,7 @@ const CalendarTemplate: React.FC<Partial<CalendarProps>> = (props) => {
 };
 
 export const Default: Story = {
-  render: () => <CalendarTemplate />,
+  render: (args) => <CalendarTemplate {...args} />,
 };
 
 export const WithFooter: Story = {
@@ -158,43 +166,54 @@ export const MultipleSelectedDates: Story = {
 };
 
 export const WithLegend: Story = {
-  render: () => (
-    <VerticalSpacing>
-      <Row>
-        <Col width="auto">
-          <CalendarTemplate
-            footer={
-              <Row>
-                <Col width="auto" className="flex align-items-center gap-2">
-                  <div
-                    style={{
-                      backgroundColor: 'var(--form-datepicker-date-selected)',
-                      width: '18px',
-                      height: '18px',
-                      borderRadius: '4px',
-                    }}
-                  ></div>{' '}
-                  Valitud
-                </Col>
-                <Col width="auto" className="flex align-items-center gap-2">
-                  <div
-                    style={{
-                      backgroundColor: 'var(--form-datepicker-date-available)',
-                      border: '1px solid var(--green-200)',
-                      width: '18px',
-                      height: '18px',
-                      borderRadius: '4px',
-                    }}
-                  ></div>{' '}
-                  Saadaval
-                </Col>
-              </Row>
-            }
-          />
-        </Col>
-      </Row>
-    </VerticalSpacing>
-  ),
+  render: () => {
+    const today = new Date();
+    const availableDays = [
+      new Date(today.getFullYear(), today.getMonth(), 9),
+      new Date(today.getFullYear(), today.getMonth(), 10),
+      new Date(today.getFullYear(), today.getMonth(), 16),
+      new Date(today.getFullYear(), today.getMonth(), 17),
+    ];
+
+    return (
+      <VerticalSpacing>
+        <Row>
+          <Col width="auto">
+            <CalendarTemplate
+              availableDays={availableDays}
+              footer={
+                <Row>
+                  <Col width="auto" className="flex align-items-center gap-2">
+                    <div
+                      style={{
+                        backgroundColor: 'var(--form-datepicker-date-selected)',
+                        width: '18px',
+                        height: '18px',
+                        borderRadius: '4px',
+                      }}
+                    ></div>{' '}
+                    Valitud
+                  </Col>
+                  <Col width="auto" className="flex align-items-center gap-2">
+                    <div
+                      style={{
+                        backgroundColor: 'var(--form-datepicker-date-available)',
+                        border: '1px solid var(--green-200)',
+                        width: '18px',
+                        height: '18px',
+                        borderRadius: '4px',
+                      }}
+                    ></div>{' '}
+                    Vabad ajad
+                  </Col>
+                </Row>
+              }
+            />
+          </Col>
+        </Row>
+      </VerticalSpacing>
+    );
+  },
 };
 
 export const Availability: Story = {

--- a/src/tedi/components/content/calendar/calendar.stories.tsx
+++ b/src/tedi/components/content/calendar/calendar.stories.tsx
@@ -24,6 +24,11 @@ const meta: Meta<typeof Calendar> = {
       type: [{ name: 'breakpointSupport', url: '?path=/docs/helpers-usebreakpointprops--usebreakpointprops' }],
     },
     controls: { exclude: ['sm', 'md', 'lg', 'xl', 'xxl'] },
+    a11y: {
+      config: {
+        rules: [{ id: 'color-contrast', enabled: false }],
+      },
+    },
   },
 };
 

--- a/src/tedi/components/content/calendar/calendar.stories.tsx
+++ b/src/tedi/components/content/calendar/calendar.stories.tsx
@@ -326,7 +326,7 @@ export const WithDayStatus: Story = {
     const day = (offset: number) => new Date(today.getFullYear(), today.getMonth(), today.getDate() + offset);
 
     const statusByDate = new Map(
-      [day(-2), day(4), day(10)].map((date) => [date.toDateString(), 'Confirmed appointment'])
+      [day(-2), day(4), day(10)].map((date) => [date.toDateString(), 'Kinnitatud vastuvõtt'])
     );
 
     const dayStatus: CalendarProps['dayStatus'] = (date) => {
@@ -340,8 +340,8 @@ export const WithDayStatus: Story = {
         footer={
           <Row>
             <Col width="auto" className="flex align-items-center gap-2">
-              <StatusIndicator type="success" size="sm" hasBorder />
-              Confirmed
+              <StatusIndicator type="success" size="sm" />
+              Kinnitatud
             </Col>
           </Row>
         }

--- a/src/tedi/components/content/calendar/calendar.tsx
+++ b/src/tedi/components/content/calendar/calendar.tsx
@@ -1,13 +1,32 @@
 import classNames from 'classnames';
 import React from 'react';
-import { DateRange, DayPicker, DayPickerProps, Locale, Matcher, OnSelectHandler } from 'react-day-picker';
+import { DateRange, DayButton, DayPicker, DayPickerProps, Locale, Matcher, OnSelectHandler } from 'react-day-picker';
 import { et } from 'react-day-picker/locale';
 
 import { CalendarView, DateFieldMode } from '../../form/date-field/date-field';
+import { StatusIndicator, StatusIndicatorType } from '../../tags/status-indicator';
 import styles from './calendar.module.scss';
 import { CalendarHeader } from './components/calendar-header/calendar-header';
 import { MonthGrid } from './components/calendar-month-grid/calendar-month-grid';
 import { YearGrid } from './components/calendar-year-grid/calendar-year-grid';
+
+export interface DayStatus {
+  /**
+   * Status type driving the indicator colour. Maps to `StatusIndicator`'s `type`.
+   */
+  type: StatusIndicatorType;
+  /**
+   * Accessible label for the status. Appended to the day button's `aria-label`
+   * so screen readers announce the date together with its status — required
+   * because the indicator dot itself is decorative (`aria-hidden`).
+   */
+  label: string;
+}
+
+/**
+ * Resolves a `DayStatus` for a given day, or `null`/`undefined` for no status.
+ */
+export type DayStatusFn = (date: Date) => DayStatus | null | undefined;
 
 export interface CalendarProps extends Omit<DayPickerProps, 'mode' | 'selected' | 'onSelect'> {
   /**
@@ -95,9 +114,19 @@ export interface CalendarProps extends Omit<DayPickerProps, 'mode' | 'selected' 
    * Forwarded to the internal `CalendarHeader`.
    * - `'dropdown'` (default) — each picker is a `<Select>` dropdown.
    * - `'grid'` — each picker opens a full grid of options.
+   * - `'static'` — the month/year is a plain, non-clickable label; only the
+   *   prev/next navigation buttons can change the month. Use to disable
+   *   month/year selection.
    * @default dropdown
    */
-  monthYearSelectType?: 'dropdown' | 'grid';
+  monthYearSelectType?: 'dropdown' | 'grid' | 'static';
+  /**
+   * Optional per-day status. Called for each rendered day; return a
+   * `{ type, label }` to overlay a `StatusIndicator` dot on that day (the
+   * `label` is folded into the day's `aria-label`), or `null` / `undefined` for
+   * no status.
+   */
+  dayStatus?: DayStatusFn;
   /**
    * Callback fired when a date or date range is selected. Receives the selected value, day, modifiers, and event.
    */
@@ -124,6 +153,16 @@ export interface CalendarProps extends Omit<DayPickerProps, 'mode' | 'selected' 
    * @default true
    */
   bordered?: boolean;
+  /**
+   * Let the calendar grow to fill the width of its container instead of using a
+   * fixed width. The seven columns distribute evenly and each cell keeps a
+   * square aspect ratio, so the day rows and the weekday row scale vertically
+   * with the width. The selected day fills its cell; the "today" ring stays a
+   * fixed size, centred. Wrap the calendar in a sized container to control how
+   * large it scales.
+   * @default false
+   */
+  fullWidth?: boolean;
 }
 
 export const Calendar = ({
@@ -143,15 +182,18 @@ export const Calendar = ({
   unavailableDays,
   footer,
   monthYearSelectType,
+  dayStatus,
   handleSelect,
   applyValue,
   showNavigation = true,
   className,
   bordered = true,
+  fullWidth = false,
   ...dayPickerProps
 }: CalendarProps) => {
   const borderlessClass = !bordered ? styles['tedi-calendar--borderless'] : undefined;
-  const containerClassName = classNames(borderlessClass, className);
+  const fullWidthClass = fullWidth ? styles['tedi-calendar--full-width'] : undefined;
+  const containerClassName = classNames(borderlessClass, fullWidthClass, className);
   const isAvailable = (date: Date) => {
     if (!availableDays) return true;
 
@@ -260,10 +302,44 @@ export const Calendar = ({
               />
             ),
             Nav: () => <></>,
+            ...(dayStatus
+              ? {
+                  DayButton: (dayButtonProps) => {
+                    const status = dayStatus(dayButtonProps.day.date);
+
+                    if (!status) {
+                      return <DayButton {...dayButtonProps} />;
+                    }
+
+                    const ariaLabel = [dayButtonProps['aria-label'], status.label].filter(Boolean).join(', ');
+
+                    return (
+                      <DayButton {...dayButtonProps} aria-label={ariaLabel}>
+                        {dayButtonProps.children}
+                        <StatusIndicator
+                          type={status.type}
+                          size="sm"
+                          hasBorder
+                          className={styles['tedi-calendar__day-status']}
+                        />
+                      </DayButton>
+                    );
+                  },
+                }
+              : {}),
+            ...(fullWidth
+              ? {
+                  Weekday: ({ children, ...weekdayProps }) => (
+                    <th {...weekdayProps}>
+                      <span className={styles['tedi-calendar__weekday-inner']}>{children}</span>
+                    </th>
+                  ),
+                }
+              : {}),
           }}
           footer={footer}
           classNames={{
-            root: classNames(styles['tedi-calendar'], borderlessClass, className),
+            root: classNames(styles['tedi-calendar'], borderlessClass, fullWidthClass, className),
             month_caption: styles['tedi-calendar__caption'],
             head: styles['tedi-calendar__head'],
             row: styles['tedi-calendar__row'],

--- a/src/tedi/components/content/calendar/calendar.tsx
+++ b/src/tedi/components/content/calendar/calendar.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { DateRange, DayButton, DayPicker, DayPickerProps, Locale, Matcher, OnSelectHandler } from 'react-day-picker';
 import { et } from 'react-day-picker/locale';
 
+import { BreakpointSupport, useBreakpointProps } from '../../../helpers';
 import { CalendarView, DateFieldMode } from '../../form/date-field/date-field';
 import { StatusIndicator, StatusIndicatorType } from '../../tags/status-indicator';
 import styles from './calendar.module.scss';
@@ -28,7 +29,7 @@ export interface DayStatus {
  */
 export type DayStatusFn = (date: Date) => DayStatus | null | undefined;
 
-export interface CalendarProps extends Omit<DayPickerProps, 'mode' | 'selected' | 'onSelect'> {
+interface CalendarBreakpointProps extends Omit<DayPickerProps, 'mode' | 'selected' | 'onSelect'> {
   /**
    * Current view of the calendar. Can be `'days'`, `'months'`, or `'years'`.
    * Controls which calendar grid is displayed.
@@ -154,43 +155,43 @@ export interface CalendarProps extends Omit<DayPickerProps, 'mode' | 'selected' 
    */
   bordered?: boolean;
   /**
-   * Let the calendar grow to fill the width of its container instead of using a
-   * fixed width. The seven columns distribute evenly and each cell keeps a
-   * square aspect ratio, so the day rows and the weekday row scale vertically
-   * with the width. The selected day fills its cell; the "today" ring stays a
-   * fixed size, centred. Wrap the calendar in a sized container to control how
-   * large it scales.
+   * Grow to fill the container's width instead of a fixed width; cells keep a
+   * square aspect ratio. Wrap in a sized container to control the scale.
    * @default false
    */
   fullWidth?: boolean;
 }
 
-export const Calendar = ({
-  view = 'days',
-  selectionLevel = 'days',
-  currentMonth,
-  setCurrentMonth,
-  setView = () => 'days',
-  mode = 'single',
-  value,
-  locale = et,
-  localeCode = 'et-EE',
-  showOutsideDays = true,
-  disabledMatchers,
-  required,
-  availableDays,
-  unavailableDays,
-  footer,
-  monthYearSelectType,
-  dayStatus,
-  handleSelect,
-  applyValue,
-  showNavigation = true,
-  className,
-  bordered = true,
-  fullWidth = false,
-  ...dayPickerProps
-}: CalendarProps) => {
+export type CalendarProps = BreakpointSupport<CalendarBreakpointProps>;
+
+export const Calendar = (props: CalendarProps) => {
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
+  const {
+    view = 'days',
+    selectionLevel = 'days',
+    currentMonth,
+    setCurrentMonth,
+    setView = () => 'days',
+    mode = 'single',
+    value,
+    locale = et,
+    localeCode = 'et-EE',
+    showOutsideDays = true,
+    disabledMatchers,
+    required,
+    availableDays,
+    unavailableDays,
+    footer,
+    monthYearSelectType,
+    dayStatus,
+    handleSelect,
+    applyValue,
+    showNavigation = true,
+    className,
+    bordered = true,
+    fullWidth = false,
+    ...dayPickerProps
+  } = getCurrentBreakpointProps<CalendarBreakpointProps>(props);
   const borderlessClass = !bordered ? styles['tedi-calendar--borderless'] : undefined;
   const fullWidthClass = fullWidth ? styles['tedi-calendar--full-width'] : undefined;
   const containerClassName = classNames(borderlessClass, fullWidthClass, className);

--- a/src/tedi/components/content/calendar/calendar.tsx
+++ b/src/tedi/components/content/calendar/calendar.tsx
@@ -316,12 +316,7 @@ export const Calendar = ({
                     return (
                       <DayButton {...dayButtonProps} aria-label={ariaLabel}>
                         {dayButtonProps.children}
-                        <StatusIndicator
-                          type={status.type}
-                          size="sm"
-                          hasBorder
-                          className={styles['tedi-calendar__day-status']}
-                        />
+                        <StatusIndicator type={status.type} size="sm" className={styles['tedi-calendar__day-status']} />
                       </DayButton>
                     );
                   },

--- a/src/tedi/components/content/calendar/components/calendar-header/calendar-header.module.scss
+++ b/src/tedi/components/content/calendar/components/calendar-header/calendar-header.module.scss
@@ -50,6 +50,7 @@
 .tedi-calendar__month-year-label {
   display: flex;
   gap: var(--layout-grid-gutters-08);
+  font-weight: 500;
   color: var(--general-text-primary);
   text-transform: capitalize;
 }

--- a/src/tedi/components/content/calendar/components/calendar-header/calendar-header.module.scss
+++ b/src/tedi/components/content/calendar/components/calendar-header/calendar-header.module.scss
@@ -58,7 +58,7 @@
 .tedi-calendar__month-year-label {
   display: flex;
   gap: var(--layout-grid-gutters-08);
-  font-weight: 500;
+  font-weight: var(--tedi-weight-02);
   color: var(--general-text-primary);
   text-transform: capitalize;
 }

--- a/src/tedi/components/content/calendar/components/calendar-header/calendar-header.module.scss
+++ b/src/tedi/components/content/calendar/components/calendar-header/calendar-header.module.scss
@@ -9,6 +9,14 @@
   }
 }
 
+.tedi-calendar__title {
+  display: flex;
+  flex: 1;
+  gap: var(--layout-grid-gutters-08);
+  align-items: center;
+  justify-content: center;
+}
+
 .tedi-calendar__month-year-dropdown {
   max-height: 15rem;
   overflow-y: auto;

--- a/src/tedi/components/content/calendar/components/calendar-header/calendar-header.spec.tsx
+++ b/src/tedi/components/content/calendar/components/calendar-header/calendar-header.spec.tsx
@@ -153,6 +153,23 @@ describe('CalendarHeader', () => {
     expect(onOpenYearGrid).toHaveBeenCalledTimes(1);
   });
 
+  it('renders a static, non-clickable month/year label when monthYearSelectType = "static"', () => {
+    render(<CalendarHeader {...defaultProps} monthYearSelectType="static" showNavigation localeCode="et" />);
+
+    expect(screen.getByText(/juuli/i)).toBeInTheDocument();
+    expect(screen.getByText('2025')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /juuli/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /2025/i })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('tedi-icon-arrow_drop_down')).not.toBeInTheDocument();
+  });
+
+  it('keeps prev/next navigation buttons in "static" mode', () => {
+    render(<CalendarHeader {...defaultProps} monthYearSelectType="static" showNavigation />);
+
+    expect(screen.getByRole('button', { name: /eelmine/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /järgmine/i })).toBeInTheDocument();
+  });
+
   it('shows correct Estonian month name', () => {
     render(
       <CalendarHeader

--- a/src/tedi/components/content/calendar/components/calendar-header/calendar-header.tsx
+++ b/src/tedi/components/content/calendar/components/calendar-header/calendar-header.tsx
@@ -14,9 +14,11 @@ export interface CalendarHeaderProps extends Pick<MonthCaptionProps, 'calendarMo
    * How the month/year selector in the calendar header is rendered.
    * - `'dropdown'` (default) — each picker is a `<Select>` dropdown.
    * - `'grid'` — each picker opens a full grid of options.
-   * @default 'dropdown'
+   * - `'static'` — the month/year is a plain, non-clickable label; the user can
+   *   only change the month via the prev/next navigation buttons.
+   * @default dropdown
    */
-  monthYearSelectType?: 'dropdown' | 'grid';
+  monthYearSelectType?: 'dropdown' | 'grid' | 'static';
   /*
    * Callback for opening month selection grid. Only used if `monthYearSelectType` is `'grid'`.
    */
@@ -53,6 +55,7 @@ export function CalendarHeader({
   disabledMatchers,
 }: CalendarHeaderProps) {
   const isGridSelect = monthYearSelectType === 'grid';
+  const isStaticLabel = monthYearSelectType === 'static' || !showNavigation;
   const { getLabel } = useLabels();
   const { goToMonth, nextMonth, previousMonth } = useNavigation();
 
@@ -118,7 +121,7 @@ export function CalendarHeader({
         </Button>
       )}
 
-      {!showNavigation ? (
+      {isStaticLabel ? (
         <div className={styles['tedi-calendar__month-year-label']}>
           <Text>{displayMonth.toLocaleString(localeCode, { month: 'long' })}</Text>
           <Text>{displayYear}</Text>

--- a/src/tedi/components/content/calendar/components/calendar-header/calendar-header.tsx
+++ b/src/tedi/components/content/calendar/components/calendar-header/calendar-header.tsx
@@ -127,7 +127,7 @@ export function CalendarHeader({
           <Text>{displayYear}</Text>
         </div>
       ) : isGridSelect ? (
-        <>
+        <div className={styles['tedi-calendar__title']}>
           <Button
             noStyle
             className={styles['tedi-calendar__month-year-selector']}
@@ -146,9 +146,9 @@ export function CalendarHeader({
             {displayMonth.getFullYear()}
             <Icon name="arrow_drop_down" color="tertiary" className={styles['tedi-calendar__month-year-caret']} />
           </Button>
-        </>
+        </div>
       ) : (
-        <>
+        <div className={styles['tedi-calendar__title']}>
           <Dropdown
             className={classNames(styles['tedi-calendar__month-year-dropdown'], {
               [styles['tedi-calendar__picker-grid-dropdown']]: isGridSelect,
@@ -217,7 +217,7 @@ export function CalendarHeader({
               ))}
             </Dropdown.Content>
           </Dropdown>
-        </>
+        </div>
       )}
 
       {showNavigation && (

--- a/src/tedi/components/form/date-field/date-field.spec.tsx
+++ b/src/tedi/components/form/date-field/date-field.spec.tsx
@@ -305,6 +305,30 @@ describe('DateField component', () => {
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
   });
 
+  describe('dayStatus (popover path)', () => {
+    const markDay15 = (date: Date) =>
+      date.getDate() === 15 ? ({ type: 'success', label: 'Kinnitatud vastuvõtt' } as const) : null;
+
+    it('renders no day-status indicator by default', async () => {
+      const user = userEvent.setup();
+      render(<DateField {...defaultProps} initialMonth={new Date(2025, 5, 1)} />);
+
+      await user.click(screen.getByRole('button'));
+      await screen.findByRole('dialog');
+      expect(document.querySelector('.tedi-calendar__day-status')).not.toBeInTheDocument();
+    });
+
+    it('forwards dayStatus to the popover calendar (dot + folded aria-label)', async () => {
+      const user = userEvent.setup();
+      render(<DateField {...defaultProps} initialMonth={new Date(2025, 5, 1)} dayStatus={markDay15} />);
+
+      await user.click(screen.getByRole('button'));
+      await screen.findByRole('dialog');
+      expect(document.querySelector('.tedi-calendar__day-status')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Kinnitatud vastuvõtt/ })).toBeInTheDocument();
+    });
+  });
+
   it('closes calendar when clicking icon again (button trigger toggle)', async () => {
     const user = userEvent.setup();
 

--- a/src/tedi/components/form/date-field/date-field.tsx
+++ b/src/tedi/components/form/date-field/date-field.tsx
@@ -26,7 +26,7 @@ import {
 } from '../../../helpers';
 import { useLabels } from '../../../providers/label-provider';
 import { UnknownType } from '../../../types/commonTypes';
-import { Calendar } from '../../content/calendar/calendar';
+import { Calendar, DayStatusFn } from '../../content/calendar/calendar';
 import type { ModalContentProps } from '../../overlays/modal/modal-content/modal-content';
 import MultiValueField, { MultiValueFieldProps } from '../multi-value-field/multi-value-field';
 import TextField, { TextFieldForwardRef, TextFieldProps } from '../textfield/textfield';
@@ -168,9 +168,17 @@ export interface DateFieldProps
    * Forwarded to the internal `Calendar` / `CalendarHeader`.
    * - `'dropdown'` (default) — each picker is a `<Select>` dropdown.
    * - `'grid'` — each picker opens a full grid of options.
+   * - `'static'` — the month/year is a plain, non-clickable label; only the
+   *   prev/next navigation buttons can change the month (disables month/year selection).
    * @default dropdown
    */
-  monthYearSelectType?: 'dropdown' | 'grid';
+  monthYearSelectType?: 'dropdown' | 'grid' | 'static';
+  /**
+   * Optional per-day status forwarded to the calendar. Return a `{ type, label }`
+   * to overlay a `StatusIndicator` dot on that day (the `label` is folded into the
+   * day's `aria-label`), or `null` / `undefined` for no status.
+   */
+  dayStatus?: DayStatusFn;
   /**
    * Show or hide the calendar header's previous/next navigation. When hidden, the month/year header
    * also becomes a static, non-interactive label (no dropdown / grid jumping) — so the calendar is
@@ -334,6 +342,7 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
     showOutsideDays = true,
     parseDate,
     monthYearSelectType,
+    dayStatus,
     showNavigation = true,
     selectionLevel = 'days',
     initialView,
@@ -891,6 +900,7 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
                   availableDays={availableDays}
                   footer={footer}
                   monthYearSelectType={monthYearSelectType}
+                  dayStatus={dayStatus}
                   showNavigation={showNavigation}
                   handleSelect={handleSelect}
                   applyValue={applyValue}

--- a/src/tedi/components/form/date-field/date-field.tsx
+++ b/src/tedi/components/form/date-field/date-field.tsx
@@ -854,6 +854,7 @@ export const DateField = React.forwardRef<TextFieldForwardRef, DateFieldProps>((
           availableDays={availableDays}
           footer={footer}
           monthYearSelectType={monthYearSelectType}
+          dayStatus={dayStatus}
           showNavigation={showNavigation}
           selectionLevel={selectionLevel}
           initialView={initialView}

--- a/src/tedi/components/form/date-field/date-picker-modal/date-picker-modal.spec.tsx
+++ b/src/tedi/components/form/date-field/date-picker-modal/date-picker-modal.spec.tsx
@@ -91,4 +91,20 @@ describe('DatePickerModal', () => {
     expect(screen.getByText(monthLabel(new Date(2025, 0, 1)))).toBeInTheDocument();
     expect(screen.getByText('2025')).toBeInTheDocument();
   });
+
+  describe('dayStatus', () => {
+    it('renders no day-status indicator by default', () => {
+      setup();
+      expect(document.querySelector('.tedi-calendar__day-status')).not.toBeInTheDocument();
+    });
+
+    it('forwards dayStatus to the calendar (dot + folded aria-label)', () => {
+      const dayStatus = (date: Date) =>
+        date.getDate() === 20 ? { type: 'success' as const, label: 'Kinnitatud vastuvõtt' } : null;
+      setup({ dayStatus });
+
+      expect(document.querySelector('.tedi-calendar__day-status')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Kinnitatud vastuvõtt/ })).toBeInTheDocument();
+    });
+  });
 });

--- a/src/tedi/components/form/date-field/date-picker-modal/date-picker-modal.tsx
+++ b/src/tedi/components/form/date-field/date-picker-modal/date-picker-modal.tsx
@@ -7,7 +7,7 @@ import { UnknownType } from '../../../../types/commonTypes';
 import { Heading } from '../../../base/typography/heading/heading';
 import Button from '../../../buttons/button/button';
 import ClosingButton from '../../../buttons/closing-button/closing-button';
-import { Calendar } from '../../../content/calendar/calendar';
+import { Calendar, DayStatusFn } from '../../../content/calendar/calendar';
 import { Modal, ModalContentProps, useModal } from '../../../overlays/modal';
 import { CalendarView } from '../date-field';
 import { resolveRangeSelection } from '../date-field-helpers';
@@ -40,6 +40,8 @@ export interface DatePickerModalProps
   availableDays?: Date[] | ((date: Date) => boolean);
   footer?: React.ReactNode;
   monthYearSelectType?: 'dropdown' | 'grid';
+  /** Per-day status overlay forwarded to `Calendar`. */
+  dayStatus?: DayStatusFn;
   showNavigation?: boolean;
   selectionLevel?: CalendarView;
   /** Grid the calendar opens on, independent of `selectionLevel`. Defaults to `selectionLevel`. */
@@ -96,6 +98,7 @@ export const DatePickerModal = (props: DatePickerModalProps): JSX.Element => {
     availableDays,
     footer,
     monthYearSelectType,
+    dayStatus,
     showNavigation,
     selectionLevel = 'days',
     initialView,
@@ -194,6 +197,7 @@ export const DatePickerModal = (props: DatePickerModalProps): JSX.Element => {
             availableDays={availableDays}
             footer={footer}
             monthYearSelectType={monthYearSelectType}
+            dayStatus={dayStatus}
             showNavigation={showNavigation}
             handleSelect={handleSelect}
             applyValue={applyValue}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full-width calendar layouts with responsive month columns and day cells.
  * Added optional status indicators and accessible labels for individual calendar days.
  * Added static month/year labels without dropdown controls.
  * Extended date fields to support day statuses and static month/year display.
* **Improvements**
  * Improved calendar header alignment, spacing, and typography.
  * Added examples demonstrating the new calendar options and responsive sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->