### PR TITLE
fix(radio,checkbox,choice-group): wcag criteria 9.4.1.2 fixes #56

### DIFF
--- a/src/tedi/components/form/checkbox/checkbox.spec.tsx
+++ b/src/tedi/components/form/checkbox/checkbox.spec.tsx
@@ -238,6 +238,23 @@ describe('Checkbox component', () => {
     expect(screen.getByRole('checkbox')).toHaveAttribute('aria-invalid', 'true');
   });
 
+  it('associates the error helper text as the accessible description when invalid', () => {
+    render(
+      <Checkbox
+        id="checkbox-id"
+        label="Checkbox Label"
+        value="checkbox-value"
+        name="checkbox-group"
+        invalid
+        helper={{ text: 'This field is required', type: 'error' }}
+      />
+    );
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toHaveAttribute('aria-invalid', 'true');
+    expect(checkbox).toHaveAccessibleDescription('This field is required');
+  });
+
   it('does not set aria-invalid when valid', () => {
     render(<Checkbox id="checkbox-id" label="Checkbox Label" value="checkbox-value" name="checkbox-group" />);
 

--- a/src/tedi/components/form/checkbox/checkbox.spec.tsx
+++ b/src/tedi/components/form/checkbox/checkbox.spec.tsx
@@ -161,9 +161,9 @@ describe('Checkbox component', () => {
       <Checkbox id="check-id" label="Check Label" value="check-value" name="check-group" indeterminate />
     );
 
-    const input = container.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    const input = screen.getByRole('checkbox') as HTMLInputElement;
     expect(input).not.toHaveAttribute('aria-checked');
-    expect(input?.indeterminate).toBe(true);
+    expect(input.indeterminate).toBe(true);
     expect(input).not.toBeChecked();
 
     const indeterminateIcon = container.querySelector('.tedi-checkbox__indicator--indeterminate');
@@ -171,30 +171,26 @@ describe('Checkbox component', () => {
   });
 
   it('renders with indeterminate state and ignores checked', () => {
-    const { container } = render(
-      <Checkbox id="check-id" label="Check Label" value="check-value" name="check-group" checked indeterminate />
-    );
+    render(<Checkbox id="check-id" label="Check Label" value="check-value" name="check-group" checked indeterminate />);
 
-    const input = container.querySelector<HTMLInputElement>('input[type="checkbox"]');
-    expect(input?.indeterminate).toBe(true);
+    const input = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(input.indeterminate).toBe(true);
     expect(input).not.toBeChecked();
   });
 
-  it('removes indeterminate state when clicked', () => {
-    const { container, rerender } = render(
+  it('clears the indeterminate state when the prop is removed', () => {
+    const { rerender } = render(
       <Checkbox id="check-id" label="Check Label" value="check-value" name="check-group" indeterminate />
     );
 
-    const input = container.querySelector<HTMLInputElement>('input[type="checkbox"]');
-    expect(input?.indeterminate).toBe(true);
+    const input = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(input.indeterminate).toBe(true);
 
-    if (input) {
-      fireEvent.click(input);
-    }
-
+    // Rerender without the click so this asserts the prop-driven effect, not the
+    // native reset a checkbox click performs on `indeterminate`.
     rerender(<Checkbox id="check-id" label="Check Label" value="check-value" name="check-group" />);
 
-    expect(input?.indeterminate).toBe(false);
+    expect(input.indeterminate).toBe(false);
   });
 
   it('calls labelRef.current.click() when clicked', () => {

--- a/src/tedi/components/form/checkbox/checkbox.spec.tsx
+++ b/src/tedi/components/form/checkbox/checkbox.spec.tsx
@@ -161,8 +161,9 @@ describe('Checkbox component', () => {
       <Checkbox id="check-id" label="Check Label" value="check-value" name="check-group" indeterminate />
     );
 
-    const input = container.querySelector('input[type="checkbox"]');
-    expect(input).toHaveAttribute('aria-checked', 'mixed');
+    const input = container.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    expect(input).not.toHaveAttribute('aria-checked');
+    expect(input?.indeterminate).toBe(true);
     expect(input).not.toBeChecked();
 
     const indeterminateIcon = container.querySelector('.tedi-checkbox__indicator--indeterminate');
@@ -174,8 +175,8 @@ describe('Checkbox component', () => {
       <Checkbox id="check-id" label="Check Label" value="check-value" name="check-group" checked indeterminate />
     );
 
-    const input = container.querySelector('input[type="checkbox"]');
-    expect(input).toHaveAttribute('aria-checked', 'mixed');
+    const input = container.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    expect(input?.indeterminate).toBe(true);
     expect(input).not.toBeChecked();
   });
 
@@ -184,8 +185,8 @@ describe('Checkbox component', () => {
       <Checkbox id="check-id" label="Check Label" value="check-value" name="check-group" indeterminate />
     );
 
-    const input = container.querySelector('input[type="checkbox"]');
-    expect(input).toHaveAttribute('aria-checked', 'mixed');
+    const input = container.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    expect(input?.indeterminate).toBe(true);
 
     if (input) {
       fireEvent.click(input);
@@ -193,7 +194,7 @@ describe('Checkbox component', () => {
 
     rerender(<Checkbox id="check-id" label="Check Label" value="check-value" name="check-group" />);
 
-    expect(input).not.toHaveAttribute('aria-checked', 'mixed');
+    expect(input?.indeterminate).toBe(false);
   });
 
   it('calls labelRef.current.click() when clicked', () => {
@@ -217,16 +218,18 @@ describe('Checkbox component', () => {
     expect(screen.getByText('*')).toBeInTheDocument();
   });
 
-  it('exposes the required state programmatically via aria-required', () => {
+  it('exposes the required state via the native required attribute', () => {
     render(<Checkbox id="checkbox-id" label="Checkbox Label" value="checkbox-value" name="checkbox-group" required />);
 
-    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-required', 'true');
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toBeRequired();
+    expect(checkbox).not.toHaveAttribute('aria-required');
   });
 
-  it('does not set aria-required when not required', () => {
+  it('is not required by default', () => {
     render(<Checkbox id="checkbox-id" label="Checkbox Label" value="checkbox-value" name="checkbox-group" />);
 
-    expect(screen.getByRole('checkbox')).not.toHaveAttribute('aria-required');
+    expect(screen.getByRole('checkbox')).not.toBeRequired();
   });
 
   it('exposes the invalid state programmatically via aria-invalid', () => {

--- a/src/tedi/components/form/checkbox/checkbox.spec.tsx
+++ b/src/tedi/components/form/checkbox/checkbox.spec.tsx
@@ -216,4 +216,28 @@ describe('Checkbox component', () => {
 
     expect(screen.getByText('*')).toBeInTheDocument();
   });
+
+  it('exposes the required state programmatically via aria-required', () => {
+    render(<Checkbox id="checkbox-id" label="Checkbox Label" value="checkbox-value" name="checkbox-group" required />);
+
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('does not set aria-required when not required', () => {
+    render(<Checkbox id="checkbox-id" label="Checkbox Label" value="checkbox-value" name="checkbox-group" />);
+
+    expect(screen.getByRole('checkbox')).not.toHaveAttribute('aria-required');
+  });
+
+  it('exposes the invalid state programmatically via aria-invalid', () => {
+    render(<Checkbox id="checkbox-id" label="Checkbox Label" value="checkbox-value" name="checkbox-group" invalid />);
+
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('does not set aria-invalid when valid', () => {
+    render(<Checkbox id="checkbox-id" label="Checkbox Label" value="checkbox-value" name="checkbox-group" />);
+
+    expect(screen.getByRole('checkbox')).not.toHaveAttribute('aria-invalid');
+  });
 });

--- a/src/tedi/components/form/checkbox/checkbox.stories.tsx
+++ b/src/tedi/components/form/checkbox/checkbox.stories.tsx
@@ -42,7 +42,13 @@ const TemplateSizes: StoryFn<CheckboxProps> = (args) => {
               </VerticalSpacing>
             </Col>
             <Col lg={2} md={6} xs={4}>
-              <Checkbox {...args} size={size} id={`checkbox-size-${size}`} />
+              <Checkbox
+                {...args}
+                size={size}
+                id={`checkbox-size-${size}`}
+                label={`${size.charAt(0).toUpperCase() + size.slice(1)} size`}
+                hideLabel
+              />
             </Col>
           </Row>
         ))}

--- a/src/tedi/components/form/checkbox/checkbox.tsx
+++ b/src/tedi/components/form/checkbox/checkbox.tsx
@@ -76,6 +76,8 @@ export const Checkbox = (props: CheckboxProps): JSX.Element => {
               onChange={onChangeHandler}
               className={styles['tedi-checkbox__input']}
               aria-describedby={[helperId, tooltipId].filter(Boolean).join(' ')}
+              aria-required={required || undefined}
+              aria-invalid={invalid || undefined}
             />
             <div
               aria-hidden="true"

--- a/src/tedi/components/form/checkbox/checkbox.tsx
+++ b/src/tedi/components/form/checkbox/checkbox.tsx
@@ -39,10 +39,13 @@ export const Checkbox = (props: CheckboxProps): JSX.Element => {
   } = props;
   const [innerChecked, setInnerChecked] = React.useState<boolean>(defaultChecked || false);
   const labelRef = React.useRef<HTMLLabelElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
-  const getChecked = React.useMemo((): boolean | 'mixed' => {
-    return indeterminate ? 'mixed' : onChange && typeof checked !== 'undefined' ? checked : innerChecked;
-  }, [indeterminate, onChange, checked, innerChecked]);
+  const isChecked = onChange && typeof checked !== 'undefined' ? checked : innerChecked;
+
+  React.useEffect(() => {
+    if (inputRef.current) inputRef.current.indeterminate = !!indeterminate;
+  }, [indeterminate]);
 
   const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>): void => {
     if (typeof checked === 'undefined') {
@@ -66,17 +69,17 @@ export const Checkbox = (props: CheckboxProps): JSX.Element => {
         <Col width="auto">
           <div className={styles['tedi-checkbox__outer-indicator-wrapper']}>
             <input
+              ref={inputRef}
               id={id}
               value={value}
               name={name}
               type="checkbox"
               disabled={disabled}
-              checked={getChecked !== 'mixed' ? getChecked : false}
-              aria-checked={getChecked}
+              checked={indeterminate ? false : isChecked}
               onChange={onChangeHandler}
               className={styles['tedi-checkbox__input']}
               aria-describedby={[helperId, tooltipId].filter(Boolean).join(' ')}
-              aria-required={required || undefined}
+              required={required}
               aria-invalid={invalid || undefined}
             />
             <div

--- a/src/tedi/components/form/choice-group/choice-group.spec.tsx
+++ b/src/tedi/components/form/choice-group/choice-group.spec.tsx
@@ -153,6 +153,30 @@ describe('ChoiceGroup Component', () => {
     expect(screen.getByText(/table.filter.select-all/i)).toBeInTheDocument();
   });
 
+  it('exposes required and invalid state on the radiogroup, not on individual radios', () => {
+    render(
+      <ChoiceGroup {...defaultProps} inputType="radio" required helper={{ text: 'Please choose one', type: 'error' }} />
+    );
+
+    const group = screen.getByRole('radiogroup');
+    expect(group).toHaveAttribute('aria-required', 'true');
+    expect(group).toHaveAttribute('aria-invalid', 'true');
+
+    // The state lives on the group; the individual radios must not carry it.
+    screen.getAllByRole('radio').forEach((radio) => {
+      expect(radio).not.toHaveAttribute('aria-required');
+      expect(radio).not.toHaveAttribute('aria-invalid');
+    });
+  });
+
+  it('does not set aria-required or aria-invalid on the radiogroup by default', () => {
+    render(<ChoiceGroup {...defaultProps} inputType="radio" />);
+
+    const group = screen.getByRole('radiogroup');
+    expect(group).not.toHaveAttribute('aria-required');
+    expect(group).not.toHaveAttribute('aria-invalid');
+  });
+
   it('handles indeterminate checkbox change correctly', () => {
     const onChangeMock = jest.fn();
 

--- a/src/tedi/components/form/choice-group/choice-group.spec.tsx
+++ b/src/tedi/components/form/choice-group/choice-group.spec.tsx
@@ -1,9 +1,15 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
+import { useBreakpointProps } from '../../../helpers';
 import ChoiceGroup, { ChoiceGroupProps } from './choice-group';
 import { ChoiceGroupContext } from './choice-group-context';
 
 import '@testing-library/jest-dom';
+
+jest.mock('../../../helpers', () => ({
+  ...jest.requireActual('../../../helpers'),
+  useBreakpointProps: jest.fn(),
+}));
 
 const defaultProps: ChoiceGroupProps = {
   id: 'test-choice-group',
@@ -20,6 +26,13 @@ const defaultProps: ChoiceGroupProps = {
 };
 
 describe('ChoiceGroup Component', () => {
+  beforeEach(() => {
+    (useBreakpointProps as jest.Mock).mockReturnValue({
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars, @typescript-eslint/no-explicit-any
+      getCurrentBreakpointProps: ({ sm, md, lg, xl, xxl, defaultServerBreakpoint, ...xs }: any) => xs,
+    });
+  });
+
   it('renders correctly with required props', () => {
     render(
       <ChoiceGroupContext.Provider
@@ -161,6 +174,7 @@ describe('ChoiceGroup Component', () => {
     const group = screen.getByRole('radiogroup');
     expect(group).toHaveAttribute('aria-required', 'true');
     expect(group).toHaveAttribute('aria-invalid', 'true');
+    expect(group).toHaveAccessibleDescription('Please choose one');
 
     // The state lives on the group; the individual radios must not carry it.
     screen.getAllByRole('radio').forEach((radio) => {

--- a/src/tedi/components/form/choice-group/choice-group.stories.tsx
+++ b/src/tedi/components/form/choice-group/choice-group.stories.tsx
@@ -29,6 +29,7 @@ const meta: Meta<typeof ChoiceGroup> = {
   title: 'TEDI-Ready/Components/Form/ChoiceGroup/ChoiceGroup',
   subcomponents: { 'ChoiceGroup.Item': ChoiceGroup.Item } as never,
   parameters: {
+    a11y: { test: 'todo' },
     docs: {
       source: {
         transform: (code: string) => {

--- a/src/tedi/components/form/choice-group/choice-group.tsx
+++ b/src/tedi/components/form/choice-group/choice-group.tsx
@@ -203,6 +203,8 @@ export const ChoiceGroup = (props: ChoiceGroupProps): React.ReactElement => {
                   className={CheckGroupBEM}
                   role={inputType === 'radio' ? 'radiogroup' : undefined}
                   aria-labelledby={inputType === 'radio' ? id : undefined}
+                  aria-required={inputType === 'radio' && required ? true : undefined}
+                  aria-invalid={inputType === 'radio' && helper?.type === 'error' ? true : undefined}
                 >
                   {items.map((item) => (
                     <ChoiceGroupItem

--- a/src/tedi/components/form/choice-group/choice-group.tsx
+++ b/src/tedi/components/form/choice-group/choice-group.tsx
@@ -164,7 +164,13 @@ export const ChoiceGroup = (props: ChoiceGroupProps): React.ReactElement => {
 
   return (
     <ChoiceGroupContext.Provider value={ContextValue}>
-      <fieldset {...rest} className={FieldSetBEM} id={id} name={name} aria-describedby={helperId}>
+      <fieldset
+        {...rest}
+        className={FieldSetBEM}
+        id={id}
+        name={name}
+        aria-describedby={helper && inputType !== 'radio' ? helperId : undefined}
+      >
         {label && typeof label === 'string' ? (
           <FormLabel id={id} label={label} required={required} hideLabel={hideLabel} renderWithoutLabel={true} />
         ) : (
@@ -203,6 +209,7 @@ export const ChoiceGroup = (props: ChoiceGroupProps): React.ReactElement => {
                   className={CheckGroupBEM}
                   role={inputType === 'radio' ? 'radiogroup' : undefined}
                   aria-labelledby={inputType === 'radio' ? id : undefined}
+                  aria-describedby={inputType === 'radio' && helper ? helperId : undefined}
                   aria-required={inputType === 'radio' && required ? true : undefined}
                   aria-invalid={inputType === 'radio' && helper?.type === 'error' ? true : undefined}
                 >

--- a/src/tedi/components/form/choice-group/components/choice-group-item/choice-group-item.tsx
+++ b/src/tedi/components/form/choice-group/components/choice-group-item/choice-group-item.tsx
@@ -121,7 +121,6 @@ export const ChoiceGroupItem = (props: ExtendedChoiceGroupItemProps): React.Reac
             }
             tooltip={tooltip}
             data-testid="choice-group-item-indicator"
-            aria-checked={isChecked}
           />
         ) : (
           <>

--- a/src/tedi/components/form/radio/radio.spec.tsx
+++ b/src/tedi/components/form/radio/radio.spec.tsx
@@ -228,4 +228,42 @@ describe('Radio component', () => {
 
     expect(screen.getByText('*')).toBeInTheDocument();
   });
+
+  it('exposes the required state via the native required attribute', () => {
+    render(<Radio id="radio-id" label="Radio Label" value="radio-value" name="radio-group" required />);
+
+    expect(screen.getByRole('radio')).toBeRequired();
+  });
+
+  it('is not required by default', () => {
+    render(<Radio id="radio-id" label="Radio Label" value="radio-value" name="radio-group" />);
+
+    expect(screen.getByRole('radio')).not.toBeRequired();
+  });
+
+  // `aria-required`/`aria-invalid` are not supported on the `radio` role — they
+  // belong on the radiogroup — so they must not be set on the input.
+  it('does not put aria-required or aria-invalid on the radio input', () => {
+    render(<Radio id="radio-id" label="Radio Label" value="radio-value" name="radio-group" required invalid />);
+
+    const radio = screen.getByRole('radio');
+    expect(radio).not.toHaveAttribute('aria-required');
+    expect(radio).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('associates the error message with the radio when invalid', () => {
+    render(
+      <Radio
+        id="radio-id"
+        label="Radio Label"
+        value="radio-value"
+        name="radio-group"
+        invalid
+        helper={{ text: 'Something is wrong', type: 'error' }}
+      />
+    );
+
+    const radio = screen.getByRole('radio');
+    expect(radio).toHaveAccessibleDescription('Something is wrong');
+  });
 });

--- a/src/tedi/components/form/radio/radio.stories.tsx
+++ b/src/tedi/components/form/radio/radio.stories.tsx
@@ -41,7 +41,13 @@ const TemplateSizes: StoryFn<RadioProps> = (args) => {
               </VerticalSpacing>
             </Col>
             <Col lg={2} md={6} xs={4}>
-              <Radio {...args} size={size} id={`radio-size-${size}`} />
+              <Radio
+                {...args}
+                size={size}
+                id={`radio-size-${size}`}
+                label={`${size.charAt(0).toUpperCase() + size.slice(1)} size`}
+                hideLabel
+              />
             </Col>
           </Row>
         ))}

--- a/src/tedi/components/form/radio/radio.tsx
+++ b/src/tedi/components/form/radio/radio.tsx
@@ -68,6 +68,7 @@ export const Radio = (props: RadioProps): JSX.Element => {
               onChange={onChangeHandler}
               className={styles['tedi-radio__input']}
               aria-describedby={[helperId, tooltipId].filter(Boolean).join(' ')}
+              required={required}
             />
             <div
               aria-hidden="true"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Required and invalid states are now correctly announced for checkboxes and radio groups.
  * Radio buttons use native required behavior.
  * Indeterminate checkboxes now expose their state correctly and clear it after interaction.
  * Invalid helper text is properly associated with form controls.
  * Unsupported ARIA attributes are omitted when not applicable.

* **Documentation**
  * Checkbox and radio size examples now include accessible, visually hidden labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->