### PR TITLE
fix(file-dropzone): map accept prop and fix input accessibility #783

### DIFF
--- a/src/tedi/components/form/file-dropzone/file-dropzone-accept.spec.tsx
+++ b/src/tedi/components/form/file-dropzone/file-dropzone-accept.spec.tsx
@@ -41,15 +41,22 @@ describe('FileDropzone accept mapping (#783)', () => {
       expect(toDropzoneAccept('.pdf, image/png')).toEqual({ '*/*': ['.pdf'], 'image/png': [] });
     });
 
-    it('returns undefined for missing/empty accept', () => {
+    it('returns undefined for missing/empty/whitespace-only accept', () => {
       expect(toDropzoneAccept(undefined)).toBeUndefined();
       expect(toDropzoneAccept('')).toBeUndefined();
+      expect(toDropzoneAccept(' , ')).toBeUndefined();
     });
   });
 
   it('has no unnamed-input or nested-interactive a11y violations', async () => {
     const { container } = render(<FileDropzone id="fd" name="file" label="Upload files" accept=".pdf,.txt" multiple />);
+    // The input is hidden via the SCSS-module class `.tedi-file-dropzone__input`, which jsdom
+    // doesn't apply — inject the rule so axe evaluates the real (display:none) state.
+    const style = document.createElement('style');
+    style.textContent = '.tedi-file-dropzone__input { display: none; }';
+    document.head.appendChild(style);
     const res = await run(container, { runOnly: ['label', 'nested-interactive', 'aria-hidden-focus'] });
+    document.head.removeChild(style);
     expect(res.violations).toEqual([]);
   });
 });

--- a/src/tedi/components/form/file-dropzone/file-dropzone-accept.spec.tsx
+++ b/src/tedi/components/form/file-dropzone/file-dropzone-accept.spec.tsx
@@ -1,0 +1,55 @@
+import { render } from '@testing-library/react';
+import { run } from 'axe-core';
+
+import FileDropzone, { toDropzoneAccept } from './file-dropzone';
+
+jest.mock('../../../providers/label-provider', () => ({
+  useLabels: () => ({ getLabel: (key: string) => key }),
+}));
+jest.mock('../../../helpers/hooks/use-file-upload', () => ({
+  useFileUpload: () => ({
+    innerFiles: [],
+    uploadErrorHelper: undefined,
+    onFileChange: jest.fn(),
+    onFileRemove: jest.fn(),
+    announcement: '',
+  }),
+}));
+
+describe('FileDropzone accept mapping (#783)', () => {
+  const acceptAttr = (accept: string): string | null => {
+    const { container } = render(<FileDropzone id="fd" name="file" label="Upload" accept={accept} multiple />);
+    return container.querySelector<HTMLInputElement>('input[type="file"]')?.getAttribute('accept') ?? null;
+  };
+
+  it('renders the input accept attribute exactly equal to the prop (extensions)', () => {
+    expect(acceptAttr('.pdf,.txt')).toBe('.pdf,.txt');
+  });
+
+  it('renders the input accept attribute exactly equal to the prop (MIME types)', () => {
+    expect(acceptAttr('image/png,image/jpeg')).toBe('image/png,image/jpeg');
+  });
+
+  it('no longer leaks the hardcoded application/* wildcard', () => {
+    expect(acceptAttr('.pdf,.txt')).not.toContain('application/*');
+  });
+
+  describe('toDropzoneAccept', () => {
+    it('groups extensions under a filtered-out */* key and keeps MIME types as keys', () => {
+      expect(toDropzoneAccept('.pdf,.txt')).toEqual({ '*/*': ['.pdf', '.txt'] });
+      expect(toDropzoneAccept('image/png')).toEqual({ 'image/png': [] });
+      expect(toDropzoneAccept('.pdf, image/png')).toEqual({ '*/*': ['.pdf'], 'image/png': [] });
+    });
+
+    it('returns undefined for missing/empty accept', () => {
+      expect(toDropzoneAccept(undefined)).toBeUndefined();
+      expect(toDropzoneAccept('')).toBeUndefined();
+    });
+  });
+
+  it('has no unnamed-input or nested-interactive a11y violations', async () => {
+    const { container } = render(<FileDropzone id="fd" name="file" label="Upload files" accept=".pdf,.txt" multiple />);
+    const res = await run(container, { runOnly: ['label', 'nested-interactive', 'aria-hidden-focus'] });
+    expect(res.violations).toEqual([]);
+  });
+});

--- a/src/tedi/components/form/file-dropzone/file-dropzone.spec.tsx
+++ b/src/tedi/components/form/file-dropzone/file-dropzone.spec.tsx
@@ -134,14 +134,13 @@ describe('FileDropzone', () => {
     const useDropzoneMock = useDropzone as jest.Mock;
     const dropzoneProps = useDropzoneMock.mock.calls[0][0];
 
-    expect(dropzoneProps.accept).toEqual({ 'application/*': ['image/png'] });
+    expect(dropzoneProps.accept).toEqual({ 'image/png': [] });
     expect(dropzoneProps.multiple).toBe(true);
     expect(dropzoneProps.maxSize).toBe(5 * 1024 ** 2);
 
     const file = new File(['file content'], 'file.png', { type: 'image/png' });
     const rejectedFile = new File(['too big'], 'big.pdf', { type: 'application/pdf' });
-    // Oversize / wrong-type rejections must still reach the hook so it validates
-    // them and surfaces feedback (WCAG 9.1.3.1 #3).
+
     dropzoneProps.onDrop([file], [{ file: rejectedFile, errors: [{ code: 'file-too-large', message: 'too large' }] }]);
 
     expect(onFileChange).toHaveBeenCalledWith({

--- a/src/tedi/components/form/file-dropzone/file-dropzone.spec.tsx
+++ b/src/tedi/components/form/file-dropzone/file-dropzone.spec.tsx
@@ -275,4 +275,10 @@ describe('FileDropzone', () => {
     );
     expect(container.querySelector('input[type="file"]')).toHaveAttribute('name', 'docs');
   });
+
+  it('associates the label with the input via the generated id fallback', () => {
+    render(<FileDropzone name="file" label="Upload File" />);
+
+    expect(screen.getByLabelText(/Upload File/)).toBe(screen.getByRole('button').querySelector('input'));
+  });
 });

--- a/src/tedi/components/form/file-dropzone/file-dropzone.spec.tsx
+++ b/src/tedi/components/form/file-dropzone/file-dropzone.spec.tsx
@@ -250,4 +250,29 @@ describe('FileDropzone', () => {
     const dropzone = screen.getByText('Upload File').closest('.tedi-file-dropzone');
     expect(dropzone).toHaveClass('tedi-file-dropzone--disabled');
   });
+
+  it('does not leak upload props onto the <label>, and puts name on the input', () => {
+    const { container } = render(
+      <FileDropzone
+        id="upload"
+        name="docs"
+        label="Label"
+        accept=".pdf,.txt"
+        maxSize={100}
+        multiple
+        validateIndividually
+        files={[]}
+        defaultFiles={[]}
+        onChange={() => undefined}
+        onDelete={() => undefined}
+        announcementTimeout={5000}
+      />
+    );
+
+    const label = container.querySelector('label');
+    ['accept', 'maxsize', 'files', 'name', 'defaultfiles', 'announcementtimeout', 'validateindividually'].forEach(
+      (attr) => expect(label).not.toHaveAttribute(attr)
+    );
+    expect(container.querySelector('input[type="file"]')).toHaveAttribute('name', 'docs');
+  });
 });

--- a/src/tedi/components/form/file-dropzone/file-dropzone.stories.tsx
+++ b/src/tedi/components/form/file-dropzone/file-dropzone.stories.tsx
@@ -129,16 +129,6 @@ export const MultipleWithIndividualValidation: Story = {
   ),
 };
 
-export const HasTooltip: Story = {
-  render: Template,
-  args: {
-    id: 'file-dropzone-tooltip',
-    name: 'file-tooltip',
-    label: 'Lohista failid siia',
-    tooltip: 'Lorem ipsum',
-  },
-};
-
 /**
  * Combines per-file validation with `attachmentProps`. The function form
  * derives `fileSize` and per-file `feedback` from each `FileUploadFile`, so the

--- a/src/tedi/components/form/file-dropzone/file-dropzone.tsx
+++ b/src/tedi/components/form/file-dropzone/file-dropzone.tsx
@@ -82,19 +82,41 @@ export const FileDropzone = (props: FileDropzoneProps): JSX.Element => {
     disabled = false,
     helper,
     id,
+    name,
     attachmentProps,
+    accept,
+    maxSize,
+    multiple,
+    validateIndividually,
+    defaultFiles,
+    files,
+    onChange,
+    onDelete,
+    announcementTimeout,
+    showRestrictions,
     ...rest
   } = props;
-  const { innerFiles, uploadErrorHelper, onFileChange, onFileRemove, announcement } = useFileUpload(props);
+  const { innerFiles, uploadErrorHelper, onFileChange, onFileRemove, announcement } = useFileUpload({
+    accept,
+    maxSize,
+    multiple,
+    validateIndividually,
+    defaultFiles,
+    files,
+    onChange,
+    onDelete,
+    announcementTimeout,
+    showRestrictions,
+  });
 
   const generatedId = React.useId();
   const resolvedId = id ?? generatedId;
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     disabled,
-    accept: toDropzoneAccept(props.accept),
-    multiple: props.multiple,
-    maxSize: props.maxSize ? props.maxSize * 1024 ** 2 : undefined,
+    accept: toDropzoneAccept(accept),
+    multiple,
+    maxSize: maxSize ? maxSize * 1024 ** 2 : undefined,
     onDrop: (acceptedFiles, fileRejections = []) => {
       if (disabled) return;
 
@@ -139,7 +161,7 @@ export const FileDropzone = (props: FileDropzoneProps): JSX.Element => {
         })}
         className={fileDropzoneBEM}
       >
-        <input {...getInputProps()} className={styles['tedi-file-dropzone__input']} disabled={disabled} />
+        <input {...getInputProps()} name={name} className={styles['tedi-file-dropzone__input']} disabled={disabled} />
         <div className={styles['tedi-file-dropzone__label-wrapper']}>
           <FormLabel
             {...rest}

--- a/src/tedi/components/form/file-dropzone/file-dropzone.tsx
+++ b/src/tedi/components/form/file-dropzone/file-dropzone.tsx
@@ -48,6 +48,30 @@ export interface FileDropzoneProps extends Omit<FormLabelProps, 'size' | 'hideLa
   attachmentProps?: FileDropzoneAttachmentProps;
 }
 
+/**
+ * Maps a comma-separated `accept` string to react-dropzone's accept-object shape
+ * (`{ [mime]: string[] }`) so the rendered input's `accept` attribute matches the
+ * prop exactly. Extensions are grouped under a wildcard key that react-dropzone
+ * drops from the attribute (it is not a valid MIME type) so only the extensions
+ * surface, while explicit MIME types stay as their own keys. Avoids the old
+ * hardcoded key that leaked the whole `application` wildcard family into the
+ * native picker and drag validation (#783).
+ */
+export const toDropzoneAccept = (accept?: string): Record<string, string[]> | undefined => {
+  if (!accept) return undefined;
+  return accept.split(',').reduce<Record<string, string[]>>((acc, token) => {
+    const value = token.trim();
+    if (!value) return acc;
+    if (value.startsWith('.')) {
+      acc['*/*'] = acc['*/*'] ?? [];
+      acc['*/*'].push(value);
+    } else {
+      acc[value] = acc[value] ?? [];
+    }
+    return acc;
+  }, {});
+};
+
 export const FileDropzone = (props: FileDropzoneProps): JSX.Element => {
   const { getLabel } = useLabels();
   const {
@@ -66,7 +90,7 @@ export const FileDropzone = (props: FileDropzoneProps): JSX.Element => {
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     disabled,
-    accept: props.accept ? { 'application/*': [props.accept] } : undefined,
+    accept: toDropzoneAccept(props.accept),
     multiple: props.multiple,
     maxSize: props.maxSize ? props.maxSize * 1024 ** 2 : undefined,
     onDrop: (acceptedFiles, fileRejections = []) => {
@@ -113,7 +137,7 @@ export const FileDropzone = (props: FileDropzoneProps): JSX.Element => {
         })}
         className={fileDropzoneBEM}
       >
-        <input {...getInputProps()} disabled={disabled} />
+        <input {...getInputProps()} style={{ display: 'none' }} disabled={disabled} />
         <div className={styles['tedi-file-dropzone__label-wrapper']}>
           <FormLabel
             {...rest}

--- a/src/tedi/components/form/file-dropzone/file-dropzone.tsx
+++ b/src/tedi/components/form/file-dropzone/file-dropzone.tsx
@@ -59,7 +59,7 @@ export interface FileDropzoneProps extends Omit<FormLabelProps, 'size' | 'hideLa
  */
 export const toDropzoneAccept = (accept?: string): Record<string, string[]> | undefined => {
   if (!accept) return undefined;
-  return accept.split(',').reduce<Record<string, string[]>>((acc, token) => {
+  const mapped = accept.split(',').reduce<Record<string, string[]>>((acc, token) => {
     const value = token.trim();
     if (!value) return acc;
     if (value.startsWith('.')) {
@@ -70,6 +70,8 @@ export const toDropzoneAccept = (accept?: string): Record<string, string[]> | un
     }
     return acc;
   }, {});
+
+  return Object.keys(mapped).length ? mapped : undefined;
 };
 
 export const FileDropzone = (props: FileDropzoneProps): JSX.Element => {
@@ -137,7 +139,7 @@ export const FileDropzone = (props: FileDropzoneProps): JSX.Element => {
         })}
         className={fileDropzoneBEM}
       >
-        <input {...getInputProps()} style={{ display: 'none' }} disabled={disabled} />
+        <input {...getInputProps()} className={styles['tedi-file-dropzone__input']} disabled={disabled} />
         <div className={styles['tedi-file-dropzone__label-wrapper']}>
           <FormLabel
             {...rest}

--- a/src/tedi/components/form/file-dropzone/file-dropzone.tsx
+++ b/src/tedi/components/form/file-dropzone/file-dropzone.tsx
@@ -93,7 +93,6 @@ export const FileDropzone = (props: FileDropzoneProps): JSX.Element => {
     onChange,
     onDelete,
     announcementTimeout,
-    showRestrictions,
     ...rest
   } = props;
   const { innerFiles, uploadErrorHelper, onFileChange, onFileRemove, announcement } = useFileUpload({
@@ -106,7 +105,6 @@ export const FileDropzone = (props: FileDropzoneProps): JSX.Element => {
     onChange,
     onDelete,
     announcementTimeout,
-    showRestrictions,
   });
 
   const generatedId = React.useId();
@@ -161,7 +159,13 @@ export const FileDropzone = (props: FileDropzoneProps): JSX.Element => {
         })}
         className={fileDropzoneBEM}
       >
-        <input {...getInputProps()} name={name} className={styles['tedi-file-dropzone__input']} disabled={disabled} />
+        <input
+          {...getInputProps()}
+          id={resolvedId}
+          name={name}
+          className={styles['tedi-file-dropzone__input']}
+          disabled={disabled}
+        />
         <div className={styles['tedi-file-dropzone__label-wrapper']}>
           <FormLabel
             {...rest}
@@ -226,5 +230,7 @@ export const FileDropzone = (props: FileDropzoneProps): JSX.Element => {
     </>
   );
 };
+
+FileDropzone.displayName = 'FileDropzone';
 
 export default FileDropzone;

--- a/src/tedi/components/form/file-upload/file-upload.tsx
+++ b/src/tedi/components/form/file-upload/file-upload.tsx
@@ -86,7 +86,7 @@ export interface FileUploadProps extends Omit<FormLabelProps, 'id' | 'label'> {
    */
   disabled?: boolean;
   /**
-   * Maximum allowed file size in bytes.
+   * Maximum allowed file size in megabytes (MB).
    */
   maxSize?: number;
   /**

--- a/src/tedi/helpers/hooks/use-file-upload.ts
+++ b/src/tedi/helpers/hooks/use-file-upload.ts
@@ -37,7 +37,7 @@ export interface UseFileUploadProps {
    */
   accept?: string;
   /**
-   * The maximum file size allowed for upload, in bytes.
+   * The maximum file size allowed for upload, in megabytes (MB).
    */
   maxSize?: number;
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file type validation for MIME types and extensions.
  - Removed the overly broad application file wildcard.
  - Improved handling when no accepted file types are specified.
  - Improved file input naming and label association for accessibility.
  - Prevented upload-related properties from being exposed on the dropzone label.

- **Enhancements**
  - Added attachment icons, upload progress, loading states, file-size formatting, and per-file validation feedback.

- **Documentation**
  - Clarified that maximum file size is specified in megabytes (MB).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->