### PR TITLE
feat(table): sticky last column prop #792

### DIFF
--- a/src/tedi/components/content/table/table.module.scss
+++ b/src/tedi/components/content/table/table.module.scss
@@ -1,4 +1,9 @@
 .tedi-table {
+  --table-sticky-divider-first: inset -1px 0 0 var(--table-border);
+  --table-sticky-divider-last: inset 1px 0 0 var(--table-border);
+  --table-sticky-shadow-first-opacity: 0;
+  --table-sticky-shadow-last-opacity: 0;
+
   display: flex;
   flex-direction: column;
   gap: var(--tedi-dimensions-10);
@@ -315,7 +320,7 @@
     left: 0;
     z-index: 2;
     background: var(--table-default);
-    box-shadow: inset -1px 0 0 var(--table-border);
+    box-shadow: var(--table-sticky-divider-first);
   }
 
   .tedi-table__row > .tedi-table__cell:first-child {
@@ -323,7 +328,24 @@
     left: 0;
     z-index: 1;
     background: var(--table-default);
-    box-shadow: inset -1px 0 0 var(--table-border);
+    box-shadow: var(--table-sticky-divider-first);
+  }
+
+  // Elevation shadow (Figma "Elevation/General/Primary") cast into the scrolling content,
+  // drawn as a soft gradient overlay — a box-shadow on the collapsed-border table cell
+  // itself is painted over by adjacent cells and never shows.
+  .tedi-table__row > .tedi-table__header-cell:first-child::after,
+  .tedi-table__row > .tedi-table__cell:first-child::after {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 100%;
+    width: 8px;
+    pointer-events: none;
+    content: '';
+    background: linear-gradient(to right, var(--tedi-alpha-10), transparent);
+    opacity: var(--table-sticky-shadow-first-opacity);
+    transition: opacity 0.15s ease;
   }
 
   &.tedi-table--striped .tedi-table__body .tedi-table__row:nth-of-type(even) > .tedi-table__cell:first-child {
@@ -348,7 +370,7 @@
     right: 0;
     z-index: 2;
     background: var(--table-default);
-    box-shadow: inset 1px 0 0 var(--table-border);
+    box-shadow: var(--table-sticky-divider-last);
   }
 
   .tedi-table__row > .tedi-table__cell:last-child {
@@ -356,7 +378,22 @@
     right: 0;
     z-index: 1;
     background: var(--table-default);
-    box-shadow: inset 1px 0 0 var(--table-border);
+    box-shadow: var(--table-sticky-divider-last);
+  }
+
+  .tedi-table__head .tedi-table__row:first-child > .tedi-table__header-cell:last-child::after,
+  .tedi-table__row--filter > .tedi-table__header-cell:last-child::after,
+  .tedi-table__row > .tedi-table__cell:last-child::after {
+    position: absolute;
+    top: 0;
+    right: 100%;
+    bottom: 0;
+    width: 8px;
+    pointer-events: none;
+    content: '';
+    background: linear-gradient(to left, var(--tedi-alpha-10), transparent);
+    opacity: var(--table-sticky-shadow-last-opacity);
+    transition: opacity 0.15s ease;
   }
 
   &.tedi-table--striped .tedi-table__body .tedi-table__row:nth-of-type(even) > .tedi-table__cell:last-child {
@@ -385,6 +422,14 @@
   }
 }
 
+.tedi-table--overflow-left {
+  --table-sticky-shadow-first-opacity: 0.7;
+}
+
+.tedi-table--overflow-right {
+  --table-sticky-shadow-last-opacity: 0.7;
+}
+
 .tedi-table--sticky-header {
   .tedi-table__head {
     border-bottom: 0;
@@ -404,12 +449,12 @@
 
   &.tedi-table--sticky-first-column .tedi-table__head .tedi-table__header-cell:first-child {
     z-index: 3;
-    box-shadow: inset -1px 0 0 var(--table-border), inset 0 -1px 0 var(--table-border-th);
+    box-shadow: var(--table-sticky-divider-first), inset 0 -1px 0 var(--table-border-th);
   }
 
   &.tedi-table--sticky-last-column .tedi-table__head .tedi-table__row:first-child > .tedi-table__header-cell:last-child,
   &.tedi-table--sticky-last-column .tedi-table__row--filter > .tedi-table__header-cell:last-child {
     z-index: 3;
-    box-shadow: inset 1px 0 0 var(--table-border), inset 0 -1px 0 var(--table-border-th);
+    box-shadow: var(--table-sticky-divider-last), inset 0 -1px 0 var(--table-border-th);
   }
 }

--- a/src/tedi/components/content/table/table.module.scss
+++ b/src/tedi/components/content/table/table.module.scss
@@ -341,6 +341,38 @@
   }
 }
 
+.tedi-table--sticky-last-column {
+  .tedi-table__row > .tedi-table__header-cell:last-child {
+    position: sticky;
+    right: 0;
+    z-index: 2;
+    background: var(--table-default);
+    box-shadow: inset 1px 0 0 var(--table-border);
+  }
+
+  .tedi-table__row > .tedi-table__cell:last-child {
+    position: sticky;
+    right: 0;
+    z-index: 1;
+    background: var(--table-default);
+    box-shadow: inset 1px 0 0 var(--table-border);
+  }
+
+  &.tedi-table--striped .tedi-table__body .tedi-table__row:nth-of-type(even) > .tedi-table__cell:last-child {
+    background: var(--table-striped);
+  }
+
+  .tedi-table__body .tedi-table__row.tedi-table__row--selected > .tedi-table__cell:last-child {
+    background: var(--table-active);
+  }
+
+  &.tedi-table--row-hover .tedi-table__body .tedi-table__row:hover > .tedi-table__cell:last-child,
+  .tedi-table__body .tedi-table__row.tedi-table__row--active > .tedi-table__cell:last-child,
+  .tedi-table__body .tedi-table__row.tedi-table__row--active:hover > .tedi-table__cell:last-child {
+    background: var(--table-hover);
+  }
+}
+
 .tedi-table--sticky-header {
   .tedi-table__head {
     border-bottom: 0;
@@ -361,5 +393,10 @@
   &.tedi-table--sticky-first-column .tedi-table__head .tedi-table__header-cell:first-child {
     z-index: 3;
     box-shadow: inset -1px 0 0 var(--table-border), inset 0 -1px 0 var(--table-border-th);
+  }
+
+  &.tedi-table--sticky-last-column .tedi-table__head .tedi-table__header-cell:last-child {
+    z-index: 3;
+    box-shadow: inset 1px 0 0 var(--table-border), inset 0 -1px 0 var(--table-border-th);
   }
 }

--- a/src/tedi/components/content/table/table.module.scss
+++ b/src/tedi/components/content/table/table.module.scss
@@ -342,7 +342,8 @@
 }
 
 .tedi-table--sticky-last-column {
-  .tedi-table__row > .tedi-table__header-cell:last-child {
+  .tedi-table__head .tedi-table__row:first-child > .tedi-table__header-cell:last-child,
+  .tedi-table__row--filter > .tedi-table__header-cell:last-child {
     position: sticky;
     right: 0;
     z-index: 2;
@@ -362,8 +363,19 @@
     background: var(--table-striped);
   }
 
-  .tedi-table__body .tedi-table__row.tedi-table__row--selected > .tedi-table__cell:last-child {
+  .tedi-table__body .tedi-table__row--sub-row > .tedi-table__cell:last-child,
+  .tedi-table__body .tedi-table__row--sub-component > .tedi-table__cell:last-child {
+    background: var(--table-striped);
+  }
+
+  .tedi-table__body .tedi-table__row.tedi-table__row--selected > .tedi-table__cell:last-child,
+  .tedi-table__body .tedi-table__row--dragging > .tedi-table__cell:last-child,
+  .tedi-table__body .tedi-table__row--picked-up > .tedi-table__cell:last-child {
     background: var(--table-active);
+  }
+
+  .tedi-table__row--filter > .tedi-table__header-cell:last-child {
+    background: var(--general-surface-primary);
   }
 
   &.tedi-table--row-hover .tedi-table__body .tedi-table__row:hover > .tedi-table__cell:last-child,
@@ -395,7 +407,8 @@
     box-shadow: inset -1px 0 0 var(--table-border), inset 0 -1px 0 var(--table-border-th);
   }
 
-  &.tedi-table--sticky-last-column .tedi-table__head .tedi-table__header-cell:last-child {
+  &.tedi-table--sticky-last-column .tedi-table__head .tedi-table__row:first-child > .tedi-table__header-cell:last-child,
+  &.tedi-table--sticky-last-column .tedi-table__row--filter > .tedi-table__header-cell:last-child {
     z-index: 3;
     box-shadow: inset 1px 0 0 var(--table-border), inset 0 -1px 0 var(--table-border-th);
   }

--- a/src/tedi/components/content/table/table.spec.tsx
+++ b/src/tedi/components/content/table/table.spec.tsx
@@ -498,6 +498,7 @@ describe('Table', () => {
       ['verticalBorders', '--vertical-borders'],
       ['borderless', '--borderless'],
       ['stickyFirstColumn', '--sticky-first-column'],
+      ['stickyLastColumn', '--sticky-last-column'],
       ['stickyHeader', '--sticky-header'],
     ] as const;
 

--- a/src/tedi/components/content/table/table.stories.tsx
+++ b/src/tedi/components/content/table/table.stories.tsx
@@ -1585,6 +1585,24 @@ export const StickyFirstColumn: Story = {
 };
 
 /**
+ * Last column stays fixed during horizontal scroll via `stickyLastColumn` — useful for a
+ * trailing actions column.
+ */
+export const StickyLastColumn: Story = {
+  render: () => (
+    <div style={{ maxWidth: 600 }}>
+      <Table<StickyDoctor>
+        id="tedi-table-sticky-last"
+        data={stickyDoctors}
+        columns={stickyDoctorColumns}
+        stickyLastColumn
+        pagination={DEFAULT_PAGINATION}
+      />
+    </div>
+  ),
+};
+
+/**
  * Header row stays pinned during vertical scroll via `stickyHeader` + `maxHeight`. The Table's
  * internal `.tedi-table__scroll` div is the sticky anchor — wrapping the Table in an external
  * scrollable container will NOT work, because `position: sticky` always resolves against the

--- a/src/tedi/components/content/table/table.tsx
+++ b/src/tedi/components/content/table/table.tsx
@@ -1116,6 +1116,32 @@ function TableBase<TData>(props: TableProps<TData>): JSX.Element {
 
   const scrollRef = useRef<HTMLDivElement>(null);
 
+  const [scrollOverflow, setScrollOverflow] = useState({ left: false, right: false });
+  const stickyColumnsEnabled = stickyFirstColumn || stickyLastColumn;
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !stickyColumnsEnabled) return;
+
+    const update = () => {
+      const left = el.scrollLeft > 0;
+      const right = Math.ceil(el.scrollLeft + el.clientWidth) < el.scrollWidth;
+      setScrollOverflow((prev) => (prev.left === left && prev.right === right ? prev : { left, right }));
+    };
+
+    update();
+    el.addEventListener('scroll', update, { passive: true });
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+
+    if (el.firstElementChild) observer.observe(el.firstElementChild);
+
+    return () => {
+      el.removeEventListener('scroll', update);
+      observer.disconnect();
+    };
+  }, [stickyColumnsEnabled]);
+
   const resetScrollTop = useCallback(() => {
     if (scrollRef.current) scrollRef.current.scrollTop = 0;
   }, []);
@@ -1148,6 +1174,8 @@ function TableBase<TData>(props: TableProps<TData>): JSX.Element {
       [styles['tedi-table--borderless']]: borderless,
       [styles['tedi-table--sticky-first-column']]: stickyFirstColumn,
       [styles['tedi-table--sticky-last-column']]: stickyLastColumn,
+      [styles['tedi-table--overflow-left']]: stickyFirstColumn && scrollOverflow.left,
+      [styles['tedi-table--overflow-right']]: stickyLastColumn && scrollOverflow.right,
       [styles['tedi-table--sticky-header']]: stickyHeader,
       [styles['tedi-table--clickable-rows']]: Boolean(onRowClick) || rowExpandsOnClick,
       [styles['tedi-table--row-hover']]: hoverEnabled,

--- a/src/tedi/components/content/table/table.tsx
+++ b/src/tedi/components/content/table/table.tsx
@@ -292,6 +292,12 @@ export interface TableProps<TData> {
    */
   stickyFirstColumn?: boolean;
   /**
+   * Freezes the last column during horizontal scroll — typically a trailing
+   * actions column that should stay reachable while a wide table scrolls.
+   * @default false
+   */
+  stickyLastColumn?: boolean;
+  /**
    * Pins the `<thead>` row(s) to the top during vertical scroll. Requires
    * `maxHeight` so the table's internal scroll container becomes the sticky
    * anchor — wrapping the Table in an external scrollable div will NOT work,
@@ -770,6 +776,7 @@ function TableBase<TData>(props: TableProps<TData>): JSX.Element {
     verticalBorders = false,
     borderless = false,
     stickyFirstColumn = false,
+    stickyLastColumn = false,
     stickyHeader = false,
     maxHeight,
     onRowClick,
@@ -1140,6 +1147,7 @@ function TableBase<TData>(props: TableProps<TData>): JSX.Element {
       [styles['tedi-table--vertical-borders']]: verticalBorders,
       [styles['tedi-table--borderless']]: borderless,
       [styles['tedi-table--sticky-first-column']]: stickyFirstColumn,
+      [styles['tedi-table--sticky-last-column']]: stickyLastColumn,
       [styles['tedi-table--sticky-header']]: stickyHeader,
       [styles['tedi-table--clickable-rows']]: Boolean(onRowClick) || rowExpandsOnClick,
       [styles['tedi-table--row-hover']]: hoverEnabled,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for keeping the last table column visible while horizontally scrolling.
  * Added styling for sticky columns, including row states, striped backgrounds, separators, and sticky headers.
  * Added an example demonstrating the sticky last-column behavior.

* **Tests**
  * Added coverage to verify the sticky last-column option is applied correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->