### PR TITLE
fix(textarea): rename TextArea to Textarea and fix screen reader bugs #758

### DIFF
--- a/skills/tedi-react/SKILL.md
+++ b/skills/tedi-react/SKILL.md
@@ -154,7 +154,7 @@ const [email, setEmail] = useState('');
 <Checkbox id="agree" label="I agree" value="agree" onChange={(val, checked) => setAgreed(checked)} />
 ```
 
-Form controls: `TextField`, `Select`, `TextArea`, `NumberField`, `Checkbox`, `Radio`, `ChoiceGroup`, `Search`, `DateField`, `TimeField`, `Filter` (+ `FilterGroup`), `FileUpload`, `FileDropzone`.
+Form controls: `TextField`, `Select`, `Textarea`, `NumberField`, `Checkbox`, `Radio`, `ChoiceGroup`, `Search`, `DateField`, `TimeField`, `Filter` (+ `FilterGroup`), `FileUpload`, `FileDropzone`.
 
 ## Theming
 

--- a/skills/tedi-react/references/components.md
+++ b/skills/tedi-react/references/components.md
@@ -660,7 +660,7 @@ Both are accessible by **mouse and keyboard**. A grip handle (`≡`) is added to
 
 ### Textarea
 
-**Props:** `TextAreaProps` extends TextFieldProps | fRef, bp, form
+**Props:** `TextareaProps` extends TextFieldProps | fRef, bp, form
 
 - `characterLimit?: number`
 

--- a/skills/tedi-react/references/components.md
+++ b/skills/tedi-react/references/components.md
@@ -658,7 +658,7 @@ Both are accessible by **mouse and keyboard**. A grip handle (`≡`) is added to
 <Select id="country" label="Country" options={countries} value={sel} onChange={setSel} />
 ```
 
-### TextArea
+### Textarea
 
 **Props:** `TextAreaProps` extends TextFieldProps | fRef, bp, form
 

--- a/skills/tedi-react/references/forms.md
+++ b/skills/tedi-react/references/forms.md
@@ -7,7 +7,7 @@ TEDI form controls support both **controlled** and **uncontrolled** modes, follo
 | Component | Value Type | Key Features |
 |-----------|-----------|--------------|
 | TextField | `string` | Icon, clearable, size variants |
-| TextArea | `string` | Character limit counter |
+| Textarea | `string` | Character limit counter |
 | NumberField | `number` | Min/max, step, suffix, increment buttons |
 | Select | `ISelectOption \| ISelectOption[] \| null` | Async, multi-select, searchable |
 | Checkbox | `boolean` (via onChange) | Indeterminate state |

--- a/src/community/components/feedback/feedback.stories.tsx
+++ b/src/community/components/feedback/feedback.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryFn } from '@storybook/react-vite';
 
 import { Heading } from '../../../tedi/components/base/typography/heading/heading';
 import { Section } from '../../../tedi/components/content/section/section';
-import { TextArea } from '../../../tedi/components/form/textarea/textarea';
+import { Textarea } from '../../../tedi/components/form/textarea/textarea';
 import TextField from '../../../tedi/components/form/textfield/textfield';
 import { Col, Row } from '../../../tedi/components/layout/grid';
 import { VerticalSpacing } from '../../../tedi/components/layout/vertical-spacing';
@@ -57,7 +57,7 @@ const Template: StoryFn<FeedbackProps> = (args) => {
                 text: '0/200',
               }}
             />
-            <TextArea
+            <Textarea
               id="content"
               label="Content"
               helper={{

--- a/src/tedi/components/form/textarea/textarea.spec.tsx
+++ b/src/tedi/components/form/textarea/textarea.spec.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 
 import { useBreakpointProps } from '../../../helpers';
 import { UnknownType } from '../../../types/commonTypes';
-import TextArea, { TextAreaProps } from './textarea';
+import Textarea, { TextareaProps } from './textarea';
 
 import '@testing-library/jest-dom';
 
@@ -11,22 +11,22 @@ jest.mock('../../../helpers', () => ({
   useBreakpointProps: jest.fn(),
 }));
 
-describe('TextArea component', () => {
+describe('Textarea component', () => {
   beforeEach(() => {
     (useBreakpointProps as jest.Mock).mockReturnValue({
       getCurrentBreakpointProps: jest.fn((props) => props),
     });
   });
 
-  const defaultProps: TextAreaProps = {
+  const defaultProps: TextareaProps = {
     id: 'test-textarea',
     label: 'Test Label',
     placeholder: 'Enter text...',
     name: 'testTextarea',
   };
 
-  it('renders the TextArea with default properties', () => {
-    render(<TextArea {...defaultProps} />);
+  it('renders the Textarea with default properties', () => {
+    render(<Textarea {...defaultProps} />);
     const textarea = screen.getByPlaceholderText(/enter text/i);
     expect(textarea).toBeInTheDocument();
     expect(textarea).toHaveAttribute('id', 'test-textarea');
@@ -34,7 +34,7 @@ describe('TextArea component', () => {
   });
 
   it('applies the correct CSS classes', () => {
-    render(<TextArea {...defaultProps} className="custom-class" />);
+    render(<Textarea {...defaultProps} className="custom-class" />);
     const wrapper = screen.getByRole('textbox').closest('div[data-name="textarea"]');
     expect(wrapper).toHaveClass('tedi-textarea', 'custom-class');
     const textarea = screen.getByRole('textbox');
@@ -44,7 +44,7 @@ describe('TextArea component', () => {
   it('displays error when char count exceeds characterLimit', () => {
     const charLimit = 10;
     const newText = 'This text is too long';
-    render(<TextArea {...defaultProps} characterLimit={charLimit} />);
+    render(<Textarea {...defaultProps} characterLimit={charLimit} />);
     const textarea = screen.getByPlaceholderText(/enter text/i);
     fireEvent.change(textarea, { target: { value: newText } });
 
@@ -53,7 +53,7 @@ describe('TextArea component', () => {
   });
 
   it('displays character counter as hint when under limit', () => {
-    render(<TextArea {...defaultProps} characterLimit={15} />);
+    render(<Textarea {...defaultProps} characterLimit={15} />);
     const textarea = screen.getByPlaceholderText(/enter text/i);
     fireEvent.change(textarea, { target: { value: 'Short text' } });
 
@@ -62,7 +62,7 @@ describe('TextArea component', () => {
   });
 
   it('displays a character counter when characterLimit is set', () => {
-    render(<TextArea {...defaultProps} characterLimit={15} />);
+    render(<Textarea {...defaultProps} characterLimit={15} />);
     const textarea = screen.getByPlaceholderText(/enter text/i);
     fireEvent.change(textarea, { target: { value: 'Some text' } });
     const counter = screen.getByText(/9\/15/i);
@@ -70,7 +70,7 @@ describe('TextArea component', () => {
   });
 
   it('does not display a character counter when characterLimit is not set', () => {
-    render(<TextArea {...defaultProps} />);
+    render(<Textarea {...defaultProps} />);
     const textarea = screen.getByPlaceholderText(/enter text/i);
     fireEvent.change(textarea, { target: { value: 'Some text' } });
     const counter = screen.queryByText(/\d+\/\d+/i);
@@ -78,7 +78,7 @@ describe('TextArea component', () => {
   });
 
   it('applies minRows when autoGrow is enabled', () => {
-    render(<TextArea {...defaultProps} autoGrow minRows={5} />);
+    render(<Textarea {...defaultProps} autoGrow minRows={5} />);
     const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
     expect(textarea).toHaveAttribute('rows', '5');
   });
@@ -105,7 +105,7 @@ describe('TextArea component', () => {
       },
     });
 
-    render(<TextArea {...defaultProps} autoGrow minRows={3} maxRows={10} />);
+    render(<Textarea {...defaultProps} autoGrow minRows={3} maxRows={10} />);
     const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
     expect(textarea).toHaveAttribute('rows', '3');
 
@@ -145,7 +145,7 @@ describe('TextArea component', () => {
       },
     });
 
-    render(<TextArea {...defaultProps} autoGrow minRows={3} maxRows={5} />);
+    render(<Textarea {...defaultProps} autoGrow minRows={3} maxRows={5} />);
 
     const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
 
@@ -166,45 +166,45 @@ describe('TextArea component', () => {
   });
 
   it('applies maxHeight when autoGrow=true', () => {
-    render(<TextArea {...defaultProps} autoGrow maxHeight="200px" />);
+    render(<Textarea {...defaultProps} autoGrow maxHeight="200px" />);
     const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
     expect(textarea.style.maxHeight).toBe('200px');
   });
 
   // === Fixed height (non-autoGrow) Tests ===
   it('applies fixed height when autoGrow=false (default)', () => {
-    render(<TextArea {...defaultProps} height="200px" />);
+    render(<Textarea {...defaultProps} height="200px" />);
     const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
     expect(textarea.style.height).toBe('200px');
   });
 
   it('uses default height 7.5rem when not specified and autoGrow=false', () => {
-    render(<TextArea {...defaultProps} />);
+    render(<Textarea {...defaultProps} />);
     const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
     expect(textarea.style.height).toBe('7.5rem');
   });
 
   it('applies maxHeight when autoGrow=false', () => {
-    render(<TextArea {...defaultProps} height="150px" maxHeight="300px" />);
+    render(<Textarea {...defaultProps} height="150px" maxHeight="300px" />);
     const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
     expect(textarea.style.height).toBe('150px');
     expect(textarea.style.maxHeight).toBe('300px');
   });
 
   it('disables the textarea when disabled prop is true', () => {
-    render(<TextArea {...defaultProps} disabled />);
+    render(<Textarea {...defaultProps} disabled />);
     const textarea = screen.getByPlaceholderText(/enter text/i);
     expect(textarea).toBeDisabled();
   });
 
   it('renders helper text when provided', () => {
-    render(<TextArea {...defaultProps} helper={{ type: 'hint', text: 'Helper text', id: 'helper-id' }} />);
+    render(<Textarea {...defaultProps} helper={{ type: 'hint', text: 'Helper text', id: 'helper-id' }} />);
     const helper = screen.getByText(/helper text/i);
     expect(helper).toBeInTheDocument();
   });
 
   it('displays validation error if invalid prop is true', () => {
-    render(<TextArea {...defaultProps} invalid helper={{ type: 'error', text: 'Error message' }} />);
+    render(<Textarea {...defaultProps} invalid helper={{ type: 'error', text: 'Error message' }} />);
     const error = screen.getByText(/error message/i);
     expect(error).toHaveClass('tedi-feedback-text--error');
   });
@@ -212,7 +212,7 @@ describe('TextArea component', () => {
   it('applies defaultValue correctly when component is uncontrolled', async () => {
     const user = userEvent.setup();
     const defaultValue = 'Initial text';
-    render(<TextArea {...defaultProps} defaultValue={defaultValue} />);
+    render(<Textarea {...defaultProps} defaultValue={defaultValue} />);
 
     const textarea = screen.getByRole('textbox');
     expect(textarea).toHaveValue(defaultValue);
@@ -228,7 +228,7 @@ describe('TextArea component', () => {
     const initialValue = 'Initial Value';
     const newValue = 'New Value';
 
-    render(<TextArea {...defaultProps} value={initialValue} onChange={handleChange} placeholder="Enter text" />);
+    render(<Textarea {...defaultProps} value={initialValue} onChange={handleChange} placeholder="Enter text" />);
     const textarea = screen.getByRole('textbox');
     expect(textarea).toHaveValue(initialValue);
 
@@ -249,7 +249,7 @@ describe('TextArea component', () => {
       currentValue = event.target.value;
     };
 
-    const { rerender } = render(<TextArea {...defaultProps} value={currentValue} onChangeEvent={handleChangeEvent} />);
+    const { rerender } = render(<Textarea {...defaultProps} value={currentValue} onChangeEvent={handleChangeEvent} />);
 
     const textarea = screen.getByRole('textbox');
     expect(textarea).toHaveValue(initialValue);
@@ -257,7 +257,7 @@ describe('TextArea component', () => {
     const newValue = 'Changed value';
     fireEvent.change(textarea, { target: { value: newValue } });
 
-    rerender(<TextArea {...defaultProps} value={currentValue} onChangeEvent={handleChangeEvent} />);
+    rerender(<Textarea {...defaultProps} value={currentValue} onChangeEvent={handleChangeEvent} />);
     expect(textarea).toHaveValue(newValue);
     expect(currentValue).toBe(newValue);
   });

--- a/src/tedi/components/form/textarea/textarea.stories.tsx
+++ b/src/tedi/components/form/textarea/textarea.stories.tsx
@@ -4,16 +4,16 @@ import { useState } from 'react';
 import { Text } from '../../base/typography/text/text';
 import { Col, Row } from '../../layout/grid';
 import { VerticalSpacing } from '../../layout/vertical-spacing';
-import TextArea, { TextAreaProps } from './textarea';
+import Textarea, { TextareaProps } from './textarea';
 
 /**
  * <a href="https://www.figma.com/design/jWiRIXhHRxwVdMSimKX2FF/TEDI-READY-(work-in-progress)?node-id=3486-37618&m=dev" target="_BLANK">Figma ↗</a><br/>
  * <a href="https://www.tedi.ee/1ee8444b7/p/25f281-text-area" target="_BLANK">Zeroheight ↗</a>
  */
 
-const meta: Meta<typeof TextArea> = {
-  component: TextArea,
-  title: 'TEDI-Ready/Components/Form/TextArea',
+const meta: Meta<typeof Textarea> = {
+  component: Textarea,
+  title: 'TEDI-Ready/Components/Form/Textarea',
   parameters: {
     status: {
       type: [{ name: 'breakpointSupport', url: '?path=/docs/helpers-usebreakpointprops--usebreakpointprops' }],
@@ -29,11 +29,11 @@ const meta: Meta<typeof TextArea> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof TextArea>;
+type Story = StoryObj<typeof Textarea>;
 
 const stateArray = ['Default', 'Hover', 'Focus', 'Active', 'Disabled'];
 
-interface TemplateStateProps extends TextAreaProps {
+interface TemplateStateProps extends TextareaProps {
   array: typeof stateArray;
 }
 
@@ -48,7 +48,7 @@ const TemplateColumnWithStates: StoryFn<TemplateStateProps> = (args) => {
             <Text modifiers="bold">{state}</Text>
           </Col>
           <Col>
-            <TextArea disabled={state === 'Disabled'} {...textFieldProps} id={state} />
+            <Textarea disabled={state === 'Disabled'} {...textFieldProps} id={state} />
           </Col>
         </Row>
       ))}
@@ -57,7 +57,7 @@ const TemplateColumnWithStates: StoryFn<TemplateStateProps> = (args) => {
           <Text modifiers="bold">Success</Text>
         </Col>
         <Col>
-          <TextArea
+          <Textarea
             {...textFieldProps}
             id="success-textarea"
             helper={{
@@ -72,7 +72,7 @@ const TemplateColumnWithStates: StoryFn<TemplateStateProps> = (args) => {
           <Text modifiers="bold">Error</Text>
         </Col>
         <Col>
-          <TextArea
+          <Textarea
             {...textFieldProps}
             id="error-textarea"
             helper={{
@@ -88,7 +88,7 @@ const TemplateColumnWithStates: StoryFn<TemplateStateProps> = (args) => {
 
 const sizesArray: Array<'default' | 'small'> = ['default', 'small'];
 
-const TemplateSizes: StoryFn<TextAreaProps> = (args) => {
+const TemplateSizes: StoryFn<TextareaProps> = (args) => {
   return (
     <div className="example-list">
       {sizesArray.map((size, key) => (
@@ -97,7 +97,7 @@ const TemplateSizes: StoryFn<TextAreaProps> = (args) => {
             <Text modifiers="bold">{size.charAt(0).toUpperCase() + size.slice(1)}</Text>
           </Col>
           <Col width={12} sm={10}>
-            <TextArea {...args} size={size} id={`textarea-size-${size}`} />
+            <Textarea {...args} size={size} id={`textarea-size-${size}`} />
           </Col>
         </Row>
       ))}
@@ -105,15 +105,15 @@ const TemplateSizes: StoryFn<TextAreaProps> = (args) => {
   );
 };
 
-const TemplateTextValue: StoryFn<TextAreaProps> = (args) => {
+const TemplateTextValue: StoryFn<TextareaProps> = (args) => {
   const { value, ...props } = args;
   const [text, setText] = useState(value ?? '');
-  return <TextArea value={text} onChange={(t) => setText(t)} {...props} />;
+  return <Textarea value={text} onChange={(t) => setText(t)} {...props} />;
 };
 
 export const Default: Story = {
   args: {
-    id: 'example-1',
+    id: 'textarea-default',
     label: 'Label',
   },
 };
@@ -121,7 +121,7 @@ export const Default: Story = {
 export const Sizes: Story = {
   render: TemplateSizes,
   args: {
-    id: 'example-1',
+    id: 'textarea-sizes',
     label: 'Label',
   },
 };
@@ -143,7 +143,7 @@ export const States: StoryObj<TemplateStateProps> = {
 
 export const WithHint: Story = {
   args: {
-    id: 'example-1',
+    id: 'textarea-with-hint',
     label: 'Label',
     helper: { text: 'Hint text' },
   },
@@ -151,7 +151,7 @@ export const WithHint: Story = {
 
 export const HintTextAndCharacterCount: Story = {
   args: {
-    id: 'example-1',
+    id: 'textarea-hint-and-count',
     label: 'Label',
     characterLimit: 400,
     helper: [{ text: 'Hint text' }],
@@ -160,7 +160,7 @@ export const HintTextAndCharacterCount: Story = {
 
 export const OnlyCharacterCount: Story = {
   args: {
-    id: 'example-1',
+    id: 'textarea-only-count',
     label: 'Label',
     characterLimit: 400,
   },
@@ -169,7 +169,7 @@ export const OnlyCharacterCount: Story = {
 export const TextValue: Story = {
   render: TemplateTextValue,
   args: {
-    id: 'example-1',
+    id: 'textarea-text-value',
     label: 'Label',
     value: 'Text value',
   },
@@ -177,7 +177,7 @@ export const TextValue: Story = {
 
 export const Placeholder: Story = {
   args: {
-    id: 'example-1',
+    id: 'textarea-placeholder',
     label: 'Label',
     placeholder: 'Text value',
   },
@@ -185,13 +185,13 @@ export const Placeholder: Story = {
 
 export const DefaultValue: Story = {
   args: {
-    id: 'example-1',
+    id: 'textarea-default-value',
     label: 'Label',
     defaultValue: 'Text value',
   },
 };
 
-const TemplateHeights: StoryFn<TextAreaProps> = (args) => {
+const TemplateHeights: StoryFn<TextareaProps> = (args) => {
   return (
     <VerticalSpacing>
       <Row>
@@ -199,7 +199,7 @@ const TemplateHeights: StoryFn<TextAreaProps> = (args) => {
           <Text modifiers="bold">Fixed Height (7.5rem default)</Text>
         </Col>
         <Col>
-          <TextArea
+          <Textarea
             {...args}
             id="fixed-height-default"
             label="Label"
@@ -213,7 +213,7 @@ const TemplateHeights: StoryFn<TextAreaProps> = (args) => {
           <Text modifiers="bold">Custom Fixed Height</Text>
         </Col>
         <Col>
-          <TextArea
+          <Textarea
             {...args}
             id="custom-height"
             label="Label"
@@ -228,7 +228,7 @@ const TemplateHeights: StoryFn<TextAreaProps> = (args) => {
           <Text modifiers="bold">Auto Grow (minRows: 3, maxRows: 12)</Text>
         </Col>
         <Col>
-          <TextArea
+          <Textarea
             {...args}
             id="auto-grow"
             label="Label"
@@ -245,7 +245,7 @@ const TemplateHeights: StoryFn<TextAreaProps> = (args) => {
           <Text modifiers="bold">Auto Grow with Custom Rows</Text>
         </Col>
         <Col>
-          <TextArea
+          <Textarea
             {...args}
             id="auto-grow-custom"
             label="Label"
@@ -262,7 +262,7 @@ const TemplateHeights: StoryFn<TextAreaProps> = (args) => {
           <Text modifiers="bold">Auto Grow with Max Height</Text>
         </Col>
         <Col>
-          <TextArea
+          <Textarea
             {...args}
             id="auto-grow-max-height"
             label="Label"
@@ -283,7 +283,7 @@ export const HeightExamples: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Examples showing different height configurations for TextArea',
+        story: 'Examples showing different height configurations for Textarea',
       },
     },
   },

--- a/src/tedi/components/form/textarea/textarea.tsx
+++ b/src/tedi/components/form/textarea/textarea.tsx
@@ -5,7 +5,7 @@ import { FeedbackTextProps } from '../feedback-text/feedback-text';
 import { TextField, TextFieldForwardRef, TextFieldProps } from '../textfield/textfield';
 import styles from './textarea.module.scss';
 
-export interface TextAreaProps extends TextFieldProps {
+export interface TextareaProps extends Omit<TextFieldProps, 'icon' | 'isClearable' | 'onClear'> {
   /**
    * Maximum number of characters allowed in the textarea.
    */
@@ -41,7 +41,7 @@ export interface TextAreaProps extends TextFieldProps {
   maxHeight?: string | number;
 }
 
-export const TextArea = forwardRef<TextFieldForwardRef, TextAreaProps>((props, ref): JSX.Element => {
+export const Textarea = forwardRef<TextFieldForwardRef, TextareaProps>((props, ref): JSX.Element => {
   const {
     className,
     helper = [],
@@ -202,6 +202,6 @@ export const TextArea = forwardRef<TextFieldForwardRef, TextAreaProps>((props, r
   );
 });
 
-TextArea.displayName = 'TextArea';
+Textarea.displayName = 'Textarea';
 
-export default TextArea;
+export default Textarea;


### PR DESCRIPTION
BREAKING CHANGE: TextArea is renamed to Textarea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Renamed the form control from `TextArea` to `Textarea` for consistent usage across the product.
  * Updated the component’s available properties and examples to reflect the new name.

* **Documentation**
  * Updated form control references, headings, and component listings to use `Textarea`.

* **Tests**
  * Updated component tests and Storybook examples to use `Textarea` while preserving existing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->