### PR TITLE
fix(button-group): wcag fixes #69

### DIFF
--- a/src/tedi/components/buttons/button-group/button-group.module.scss
+++ b/src/tedi/components/buttons/button-group/button-group.module.scss
@@ -104,12 +104,12 @@
       &.tedi-button-group__item--active:not(:disabled) {
         z-index: 1;
         color: var(--button-group-secondary-selected-text);
-        outline: 2px solid var(--button-group-secondary-selected-border);
-        outline-offset: -2px;
         background-color: var(--button-group-secondary-selected-background);
+        border-color: var(--button-group-secondary-selected-border);
+        box-shadow: inset 0 0 0 1px var(--button-group-secondary-selected-border);
       }
 
-      &:focus-visible:not(:disabled, .tedi-button-group__item--active) {
+      &:focus-visible:not(:disabled) {
         color: var(--button-group-secondary-inactive-text);
         background-color: var(--button-group-secondary-inactive-background);
         border: 1px solid var(--button-group-secondary-inactive-border);

--- a/src/tedi/components/buttons/button-group/button-group.stories.tsx
+++ b/src/tedi/components/buttons/button-group/button-group.stories.tsx
@@ -117,13 +117,13 @@ const TemplateWithIcons: StoryFn<ButtonGroupProps> = (args) => {
 const TemplateIconOnly: StoryFn<ButtonGroupProps> = (args) => {
   return (
     <ButtonGroup {...args} stretch={false}>
-      <Button id="1" icon="table">
+      <Button id="1" icon="table" showTooltip>
         Tab 1
       </Button>
-      <Button id="2" icon="refresh" isActive>
+      <Button id="2" icon="refresh" isActive showTooltip>
         Tab 2
       </Button>
-      <Button id="3" icon="settings">
+      <Button id="3" icon="settings" showTooltip>
         Tab 3
       </Button>
     </ButtonGroup>
@@ -136,6 +136,7 @@ export const Default: Story = {
     type: 'primary',
     stretch: false,
     dropdownLabel: 'Text',
+    enableMobileDropdown: true,
   },
 };
 
@@ -268,5 +269,7 @@ export const Stretched: Story = {
   render: Template,
   args: {
     stretch: true,
+    dropdownLabel: 'Text',
+    enableMobileDropdown: true,
   },
 };

--- a/src/tedi/components/overlays/dropdown/dropdown-item/dropdown-item.module.scss
+++ b/src/tedi/components/overlays/dropdown/dropdown-item/dropdown-item.module.scss
@@ -123,6 +123,10 @@
     }
   }
 
+  &--active:focus-visible:not(.tedi-dropdown__item--disabled) {
+    outline-color: var(--dropdown-item-active-text);
+  }
+
   &--indent {
     padding-left: calc(var(--dropdown-indent) + var(--dropdown-item-padding-x));
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved active and focus-visible styling for secondary button groups.
  - Updated active dropdown items to use an appropriate focus outline color.

- **Bug Fixes**
  - Enabled tooltips for icon-only buttons.
  - Added the mobile dropdown and “Text” label to relevant button-group examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->