### PR TITLE
fix(toast): wcag fixes #62

### DIFF
--- a/src/tedi/components/notifications/alert/alert.module.scss
+++ b/src/tedi/components/notifications/alert/alert.module.scss
@@ -21,6 +21,10 @@
     }
   }
 
+  &__message {
+    margin-top: var(--layout-grid-gutters-04);
+  }
+
   &--size-default {
     padding: var(--alert-default-padding-y) var(--alert-default-padding-x);
     font-size: var(--body-regular-size);

--- a/src/tedi/components/notifications/alert/alert.spec.tsx
+++ b/src/tedi/components/notifications/alert/alert.spec.tsx
@@ -56,9 +56,12 @@ describe('Alert component', () => {
       </Alert>
     );
 
-    expect(container.querySelector('span[data-name="icon"]')).toBeInTheDocument();
-    expect(screen.getByText('Alert Title')).toBeInTheDocument();
-    expect(screen.getByText('Alert Content')).toBeInTheDocument();
+    const icon = container.querySelector('span[data-name="icon"]');
+    expect(icon).toBeInTheDocument();
+
+    const headRow = icon?.closest('.tedi-alert__content');
+    expect(headRow).toContainElement(screen.getByText('Alert Title'));
+    expect(headRow).not.toContainElement(screen.getByText('Alert Content'));
   });
 
   it('applies global styles when isGlobal is true', () => {

--- a/src/tedi/components/notifications/alert/alert.spec.tsx
+++ b/src/tedi/components/notifications/alert/alert.spec.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { useBreakpointProps } from '../../../helpers';
-import { Alert } from './alert';
+import { Alert, AlertProps } from './alert';
 
 jest.mock('../../../helpers', () => ({
   useBreakpointProps: jest.fn(),
@@ -47,6 +47,18 @@ describe('Alert component', () => {
     expect(iconElement).toBeInTheDocument();
     expect(iconElement).toHaveClass('tedi-icon');
     expect(iconElement).toHaveClass('tedi-icon--size-18');
+  });
+
+  it('renders the icon alongside the title in the head row', () => {
+    const { container } = render(
+      <Alert icon="info" title="Alert Title">
+        Alert Content
+      </Alert>
+    );
+
+    expect(container.querySelector('span[data-name="icon"]')).toBeInTheDocument();
+    expect(screen.getByText('Alert Title')).toBeInTheDocument();
+    expect(screen.getByText('Alert Content')).toBeInTheDocument();
   });
 
   it('applies global styles when isGlobal is true', () => {
@@ -103,6 +115,60 @@ describe('Alert component', () => {
 
     const alert = screen.getByRole('status');
     expect(alert).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('sets aria-live assertive for role="alert"', () => {
+    render(<Alert role="alert">Alert</Alert>);
+
+    expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  it('renders presentational (role="none") without live-region or name semantics', () => {
+    const { container } = render(
+      <Alert role="none" title="Presentational">
+        Body
+      </Alert>
+    );
+
+    const alert = container.querySelector('[data-name="alert"]');
+    expect(alert).toHaveAttribute('role', 'none');
+    expect(alert).not.toHaveAttribute('aria-live');
+    expect(alert).not.toHaveAttribute('aria-label');
+    expect(alert).not.toHaveAttribute('aria-labelledby');
+  });
+
+  it('does not let forwarded aria-* props re-add live-region semantics to a presentational alert', () => {
+    const injected = {
+      role: 'none',
+      'aria-live': 'assertive',
+      'aria-label': 'Injected',
+      'aria-labelledby': 'somewhere',
+    } as unknown as AlertProps;
+
+    const { container } = render(<Alert {...injected}>Body</Alert>);
+
+    const alert = container.querySelector('[data-name="alert"]');
+    expect(alert).not.toHaveAttribute('aria-live');
+    expect(alert).not.toHaveAttribute('aria-label');
+    expect(alert).not.toHaveAttribute('aria-labelledby');
+  });
+
+  it('names the alert via its title (aria-labelledby) and drops the fallback aria-label', () => {
+    render(<Alert title="Payment failed">Body</Alert>);
+
+    const alert = screen.getByRole('alert');
+    const labelledBy = alert.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+    expect(document.getElementById(labelledBy as string)).toHaveTextContent('Payment failed');
+    expect(alert).not.toHaveAttribute('aria-label');
+  });
+
+  it('falls back to a generated aria-label when there is no title', () => {
+    render(<Alert type="success">Body</Alert>);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveAttribute('aria-label', 'success alert');
+    expect(alert).not.toHaveAttribute('aria-labelledby');
   });
 
   it('renders with danger type and applies correct class', () => {

--- a/src/tedi/components/notifications/alert/alert.tsx
+++ b/src/tedi/components/notifications/alert/alert.tsx
@@ -148,11 +148,10 @@ export const Alert = (props: AlertProps): JSX.Element | null => {
     <div
       role={role}
       data-name="alert"
+      {...rest}
       aria-live={isPresentational ? undefined : ariaLive}
       aria-labelledby={!isPresentational && title ? headingId : undefined}
       aria-label={!isPresentational && !title ? `${type} alert` : undefined}
-      {...rest}
-      {...(isPresentational ? { 'aria-live': undefined, 'aria-labelledby': undefined, 'aria-label': undefined } : {})}
       className={alertBEM}
     >
       <Row gutterX={2} alignItems="start">

--- a/src/tedi/components/notifications/alert/alert.tsx
+++ b/src/tedi/components/notifications/alert/alert.tsx
@@ -152,6 +152,7 @@ export const Alert = (props: AlertProps): JSX.Element | null => {
       aria-labelledby={!isPresentational && title ? headingId : undefined}
       aria-label={!isPresentational && !title ? `${type} alert` : undefined}
       {...rest}
+      {...(isPresentational ? { 'aria-live': undefined, 'aria-labelledby': undefined, 'aria-label': undefined } : {})}
       className={alertBEM}
     >
       <Row gutterX={2} alignItems="start">

--- a/src/tedi/components/notifications/alert/alert.tsx
+++ b/src/tedi/components/notifications/alert/alert.tsx
@@ -6,7 +6,6 @@ import { Icon, IconWithoutBackgroundProps } from '../../base/icon/icon';
 import { Heading } from '../../base/typography/heading/heading';
 import { ClosingButton } from '../../buttons/closing-button/closing-button';
 import { Col, Row } from '../../layout/grid';
-import { VerticalSpacing } from '../../layout/vertical-spacing';
 import styles from './alert.module.scss';
 
 export type AlertType = 'info' | 'success' | 'warning' | 'danger';
@@ -141,45 +140,51 @@ export const Alert = (props: AlertProps): JSX.Element | null => {
     return <Icon {...iconProps} className={styles['tedi-alert__icon']} />;
   };
 
-  const ariaLive = role === 'alert' ? 'assertive' : role === 'status' ? 'polite' : 'off';
+  const isPresentational = role === 'none';
+  const ariaLive = role === 'alert' ? 'assertive' : role === 'status' ? 'polite' : undefined;
   const headingId = React.useId();
 
   return isMounted ? (
     <div
       role={role}
       data-name="alert"
-      aria-label={`${type} alert`}
-      aria-live={ariaLive}
-      aria-labelledby={title ? headingId : undefined}
+      aria-live={isPresentational ? undefined : ariaLive}
+      aria-labelledby={!isPresentational && title ? headingId : undefined}
+      aria-label={!isPresentational && !title ? `${type} alert` : undefined}
       {...rest}
       className={alertBEM}
     >
-      <VerticalSpacing size={0.25}>
-        <Row gutterX={2} alignItems={title ? 'center' : 'start'}>
-          <Col grow={1} className={styles['tedi-alert__content']}>
-            {icon && getIcon(icon)}
-            <div className="tedi-alert__content-wrapper">
-              {title ? (
+      <Row gutterX={2} alignItems="start">
+        <Col grow={1}>
+          {title ? (
+            <>
+              <div className={styles['tedi-alert__content']}>
+                {icon && getIcon(icon)}
                 <Heading element={titleElement} id={headingId} modifiers={['h5']}>
                   {title}
                 </Heading>
-              ) : (
-                children
+              </div>
+              {children && (
+                <div className={cn('tedi-alert__content-wrapper', styles['tedi-alert__message'])}>{children}</div>
               )}
-            </div>
-          </Col>
-          {action ? (
-            <Col width="auto">{action}</Col>
+            </>
           ) : (
-            onClose && (
-              <Col width="auto">
-                <ClosingButton onClick={onClose} iconSize={18} />
-              </Col>
-            )
+            <div className={styles['tedi-alert__content']}>
+              {icon && getIcon(icon)}
+              <div className="tedi-alert__content-wrapper">{children}</div>
+            </div>
           )}
-        </Row>
-        {title && children && <div className="tedi-alert__content-wrapper">{children}</div>}
-      </VerticalSpacing>
+        </Col>
+        {action ? (
+          <Col width="auto">{action}</Col>
+        ) : (
+          onClose && (
+            <Col width="auto">
+              <ClosingButton onClick={onClose} iconSize={18} />
+            </Col>
+          )
+        )}
+      </Row>
     </div>
   ) : null;
 };

--- a/src/tedi/components/notifications/toast/toast.module.scss
+++ b/src/tedi/components/notifications/toast/toast.module.scss
@@ -3,6 +3,10 @@
   --toastify-color-progress-light: transparent !important;
 }
 
+.tedi-toast__focus-wrapper {
+  display: contents;
+}
+
 .tedi-toast {
   display: block;
   width: 100%;

--- a/src/tedi/components/notifications/toast/toast.spec.tsx
+++ b/src/tedi/components/notifications/toast/toast.spec.tsx
@@ -128,6 +128,9 @@ describe('sendNotification', () => {
     });
 
     expect(onClose).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
   });
 
   test('takes the toast container out of the tab order so it is not focusable itself', async () => {

--- a/src/tedi/components/notifications/toast/toast.spec.tsx
+++ b/src/tedi/components/notifications/toast/toast.spec.tsx
@@ -130,6 +130,20 @@ describe('sendNotification', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  test('takes the toast container out of the tab order so it is not focusable itself', async () => {
+    render(<ToastContainer />);
+
+    act(() => {
+      sendNotification({ type: 'info', title: 'Heads up', children: 'ok' });
+    });
+
+    await waitFor(() => {
+      const container = document.querySelector('.Toastify__toast');
+      expect(container).not.toBeNull();
+      expect(container).toHaveAttribute('tabindex', '-1');
+    });
+  });
+
   test('pauses the timer on keyboard focus and resumes when focus leaves the toast', async () => {
     const pauseSpy = jest.spyOn(toast, 'pause');
     const playSpy = jest.spyOn(toast, 'play');

--- a/src/tedi/components/notifications/toast/toast.spec.tsx
+++ b/src/tedi/components/notifications/toast/toast.spec.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { act } from 'react';
 import { toast, ToastContainer } from 'react-toastify';
 
+import { sendNotification } from './toast';
+
 import 'react-toastify/dist/ReactToastify.css';
 
 describe('Toast Component', () => {
@@ -37,5 +39,121 @@ describe('Toast Component', () => {
     await waitFor(() => {
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     });
+  });
+});
+
+describe('sendNotification', () => {
+  afterEach(() => {
+    act(() => {
+      toast.dismiss();
+    });
+    jest.restoreAllMocks();
+  });
+
+  test('renders the title and body through the Alert', async () => {
+    render(<ToastContainer />);
+
+    act(() => {
+      sendNotification({ type: 'success', title: 'Saved', children: 'Everything worked' });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Saved')).toBeInTheDocument();
+      expect(screen.getByText('Everything worked')).toBeInTheDocument();
+    });
+  });
+
+  test('renders the inner alert as presentational so it is not a competing live region', async () => {
+    render(<ToastContainer />);
+
+    act(() => {
+      sendNotification({ type: 'success', title: 'Saved', children: 'ok' });
+    });
+
+    await waitFor(() => {
+      const alert = document.querySelector('[data-name="toast"]');
+      expect(alert).toHaveAttribute('role', 'none');
+      expect(alert).not.toHaveAttribute('aria-live');
+    });
+  });
+
+  test('maps a non-danger severity to a polite status region', async () => {
+    render(<ToastContainer />);
+
+    act(() => {
+      sendNotification({ type: 'info', title: 'Heads up', children: 'text' });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+  });
+
+  test('maps a danger severity to an assertive alert region', async () => {
+    render(<ToastContainer />);
+
+    act(() => {
+      sendNotification({ type: 'danger', title: 'Error', children: 'text' });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+
+  test('lets an explicit role prop override the severity mapping', async () => {
+    render(<ToastContainer />);
+
+    act(() => {
+      sendNotification({ type: 'danger', title: 'Error', children: 'text', role: 'status' });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeInTheDocument();
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+
+  test('calls the consumer onClose and dismisses the toast when closed', async () => {
+    const onClose = jest.fn();
+    render(<ToastContainer />);
+
+    act(() => {
+      sendNotification({ type: 'success', title: 'Saved', children: 'ok', onClose });
+    });
+
+    const closeButton = await screen.findByRole('button', { name: 'close' });
+    act(() => {
+      fireEvent.click(closeButton);
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('pauses the timer on keyboard focus and resumes when focus leaves the toast', async () => {
+    const pauseSpy = jest.spyOn(toast, 'pause');
+    const playSpy = jest.spyOn(toast, 'play');
+    render(<ToastContainer />);
+
+    act(() => {
+      sendNotification({ type: 'info', title: 'Heads up', children: 'ok' });
+    });
+
+    const closeButton = await screen.findByRole('button', { name: 'close' });
+
+    act(() => {
+      fireEvent.focusIn(closeButton);
+    });
+    expect(pauseSpy).toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.focusOut(closeButton, { relatedTarget: closeButton.parentElement });
+    });
+    const playCallsWhileInside = playSpy.mock.calls.length;
+
+    act(() => {
+      fireEvent.focusOut(closeButton, { relatedTarget: document.body });
+    });
+    expect(playSpy.mock.calls.length).toBeGreaterThan(playCallsWhileInside);
   });
 });

--- a/src/tedi/components/notifications/toast/toast.tsx
+++ b/src/tedi/components/notifications/toast/toast.tsx
@@ -11,6 +11,7 @@ const toastDefaultOptions: ToastOptions = {
   hideProgressBar: true,
   closeOnClick: true,
   pauseOnHover: true,
+  pauseOnFocusLoss: true,
   draggable: true,
   progress: undefined,
   transition: Slide,
@@ -19,25 +20,40 @@ const toastDefaultOptions: ToastOptions = {
 };
 
 export const sendNotification = (props: AlertProps, toastOptions?: ToastOptions) => {
+  const toastRole =
+    props.role === 'alert' || props.role === 'status' ? props.role : props.type === 'danger' ? 'alert' : 'status';
+
   const mergedToastOptions: ToastOptions = {
     ...toastDefaultOptions,
+    role: toastRole,
     ...toastOptions,
     progressClassName: `${styles['tedi-toast__progress']} ${styles[`tedi-toast__progress--${props.type}`]}`,
   };
 
   const id = toast(
     () => (
-      <Alert
-        data-name="toast"
-        {...props}
-        onClose={() => {
-          props.onClose?.();
-          toast.dismiss(id);
+      <div
+        className={styles['tedi-toast__focus-wrapper']}
+        onFocus={() => toast.pause({ id })}
+        onBlur={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget)) {
+            toast.play({ id });
+          }
         }}
-        className={styles['tedi-toast']}
       >
-        {props.children}
-      </Alert>
+        <Alert
+          data-name="toast"
+          {...props}
+          role="none"
+          onClose={() => {
+            props.onClose?.();
+            toast.dismiss(id);
+          }}
+          className={styles['tedi-toast']}
+        >
+          {props.children}
+        </Alert>
+      </div>
     ),
     mergedToastOptions
   );

--- a/src/tedi/components/notifications/toast/toast.tsx
+++ b/src/tedi/components/notifications/toast/toast.tsx
@@ -34,6 +34,7 @@ export const sendNotification = (props: AlertProps, toastOptions?: ToastOptions)
     () => (
       <div
         className={styles['tedi-toast__focus-wrapper']}
+        ref={(node) => node?.closest('.Toastify__toast')?.setAttribute('tabindex', '-1')}
         onFocus={() => toast.pause({ id })}
         onBlur={(event) => {
           if (!event.currentTarget.contains(event.relatedTarget)) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader announcements for alerts with role-appropriate live-region and labeling behavior.
  * Refined alert content structure for clearer navigation between titles and messages.
  * Improved keyboard focus handling for toast notifications.

* **Bug Fixes**
  * Toast notifications now pause while focused and resume when focus leaves.
  * Improved alert message spacing and preserved accessible dismissal controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->