### PR TITLE
fix(breadcrumbs): wcag fixes #22

### DIFF
--- a/src/tedi/components/navigation/breadcrumbs/breadcrumbs.spec.tsx
+++ b/src/tedi/components/navigation/breadcrumbs/breadcrumbs.spec.tsx
@@ -129,9 +129,12 @@ describe('Breadcrumbs', () => {
     );
     const trigger = screen.getByRole('button', { name: 'breadcrumbs.show-more' });
     fireEvent.click(trigger);
-    expect(screen.getByRole('link', { name: 'B' })).toHaveAttribute('href', '/b');
-    expect(screen.getByRole('link', { name: 'C' })).toHaveAttribute('href', '/c');
-    expect(screen.getByRole('link', { name: 'D' })).toHaveAttribute('href', '/d');
+
+    const itemB = screen.getByRole('menuitem', { name: 'B' });
+    expect(itemB.tagName).toBe('A');
+    expect(itemB).toHaveAttribute('href', '/b');
+    expect(screen.getByRole('menuitem', { name: 'C' })).toHaveAttribute('href', '/c');
+    expect(screen.getByRole('menuitem', { name: 'D' })).toHaveAttribute('href', '/d');
   });
 
   it('skips collapse when maxItems is not exceeded', () => {

--- a/src/tedi/components/navigation/breadcrumbs/breadcrumbs.stories.tsx
+++ b/src/tedi/components/navigation/breadcrumbs/breadcrumbs.stories.tsx
@@ -70,19 +70,19 @@ export const Default: Story = {
 export const Long: Story = {
   render: () => (
     <VerticalSpacing size={1}>
-      <Breadcrumbs>
+      <Breadcrumbs ariaLabel="Applications trail">
         <Link href="#">Dashboard</Link>
         <Link href="#">Applications</Link>
         <span aria-current="page">Application nr 506</span>
       </Breadcrumbs>
-      <Breadcrumbs>
+      <Breadcrumbs ariaLabel="Documents trail">
         <Link href="#">Dashboard</Link>
         <Link href="#">Documents</Link>
         <Link href="#">My documents</Link>
         <Link href="#">Application nr 506</Link>
         <span aria-current="page">Restrictions</span>
       </Breadcrumbs>
-      <Breadcrumbs>
+      <Breadcrumbs ariaLabel="Medications trail">
         <Link href="#">Medications</Link>
         <span aria-current="page">Ibuprofen</span>
       </Breadcrumbs>
@@ -168,19 +168,23 @@ export const ResponsiveVariant: Story = {
  * icon, or arbitrary markup. The separator is hidden from assistive technology.
  */
 export const CustomSeparator: Story = {
+  // Distinct `ariaLabel`s keep the three `<nav>` landmarks unique (axe `landmark-unique`).
   render: () => (
     <VerticalSpacing size={1}>
-      <Breadcrumbs separator="/">
+      <Breadcrumbs separator="/" ariaLabel="Slash separator">
         <Link href="#">Dashboard</Link>
         <Link href="#">Documents</Link>
         <span aria-current="page">Restrictions</span>
       </Breadcrumbs>
-      <Breadcrumbs separator={<Icon name="arrow_forward" color="inherit" size={16} aria-hidden />}>
+      <Breadcrumbs
+        separator={<Icon name="arrow_forward" color="inherit" size={16} aria-hidden />}
+        ariaLabel="Arrow separator"
+      >
         <Link href="#">Dashboard</Link>
         <Link href="#">Documents</Link>
         <span aria-current="page">Restrictions</span>
       </Breadcrumbs>
-      <Breadcrumbs separator="—">
+      <Breadcrumbs separator="—" ariaLabel="Dash separator">
         <Link href="#">Dashboard</Link>
         <Link href="#">Documents</Link>
         <span aria-current="page">Restrictions</span>

--- a/src/tedi/components/navigation/breadcrumbs/breadcrumbs.tsx
+++ b/src/tedi/components/navigation/breadcrumbs/breadcrumbs.tsx
@@ -162,11 +162,17 @@ export const Breadcrumbs = (props: BreadcrumbsProps): JSX.Element | null => {
                     </Button>
                   </Dropdown.Trigger>
                   <Dropdown.Content>
-                    {token.hidden.map((hiddenCrumb, hiddenIndex) => (
-                      <Dropdown.Item key={hiddenCrumb.key ?? hiddenIndex} index={hiddenIndex} asChild>
-                        {hiddenCrumb}
-                      </Dropdown.Item>
-                    ))}
+                    {token.hidden.map((hiddenCrumb, hiddenIndex) => {
+                      const menuCrumb =
+                        typeof hiddenCrumb.type !== 'string'
+                          ? cloneElement(hiddenCrumb, { noStyle: true })
+                          : hiddenCrumb;
+                      return (
+                        <Dropdown.Item key={hiddenCrumb.key ?? hiddenIndex} index={hiddenIndex} asChild>
+                          {menuCrumb}
+                        </Dropdown.Item>
+                      );
+                    })}
                   </Dropdown.Content>
                 </Dropdown>
               </li>

--- a/src/tedi/components/overlays/dropdown/dropdown-item/dropdown-item.spec.tsx
+++ b/src/tedi/components/overlays/dropdown/dropdown-item/dropdown-item.spec.tsx
@@ -270,28 +270,20 @@ describe('DropdownItem', () => {
       expect(mockSetOpen).toHaveBeenCalledWith(false);
     });
 
-    it('closes on Enter (letting the anchor navigate natively)', () => {
-      render(
-        <DropdownItem asChild index={0} onClick={mockOnClick}>
-          <a href="/x">Go</a>
-        </DropdownItem>
-      );
-      fireEvent.keyDown(screen.getByRole('menuitem', { name: 'Go' }), { key: 'Enter' });
-      expect(mockOnClick).toHaveBeenCalled();
-      expect(mockSetOpen).toHaveBeenCalledWith(false);
-    });
-
-    it('synthesises a click and closes on Space', () => {
+    it.each(['Enter', ' '])('activates exactly once via a single synthetic click on %s', (key) => {
       const childClick = jest.fn();
       render(
-        <DropdownItem asChild index={0}>
+        <DropdownItem asChild index={0} onClick={mockOnClick}>
           <a href="/x" onClick={childClick}>
             Go
           </a>
         </DropdownItem>
       );
-      fireEvent.keyDown(screen.getByRole('menuitem', { name: 'Go' }), { key: ' ' });
-      expect(childClick).toHaveBeenCalled();
+      fireEvent.keyDown(screen.getByRole('menuitem', { name: 'Go' }), { key });
+      // No double activation: the item callback, the child handler, and the close each run once.
+      expect(mockOnClick).toHaveBeenCalledTimes(1);
+      expect(childClick).toHaveBeenCalledTimes(1);
+      expect(mockSetOpen).toHaveBeenCalledTimes(1);
       expect(mockSetOpen).toHaveBeenCalledWith(false);
     });
 
@@ -304,6 +296,48 @@ describe('DropdownItem', () => {
         </DropdownItem>
       );
       expect(screen.getByRole('menuitem', { name: 'Go' })).toHaveClass('my-link');
+    });
+
+    it('marks a disabled slotted anchor with aria-disabled and removes it from the tab order', () => {
+      render(
+        <DropdownItem asChild index={0} disabled>
+          <a href="/x">Go</a>
+        </DropdownItem>
+      );
+      const item = screen.getByRole('menuitem', { name: 'Go' });
+      expect(item).toHaveAttribute('aria-disabled', 'true');
+      expect(item).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('does not activate a disabled slotted anchor on click', () => {
+      const childClick = jest.fn();
+      render(
+        <DropdownItem asChild index={0} disabled onClick={mockOnClick}>
+          <a href="/x" onClick={childClick}>
+            Go
+          </a>
+        </DropdownItem>
+      );
+      const clickEvent = fireEvent.click(screen.getByRole('menuitem', { name: 'Go' }));
+      expect(mockOnClick).not.toHaveBeenCalled();
+      expect(childClick).not.toHaveBeenCalled();
+      expect(mockSetOpen).not.toHaveBeenCalled();
+      expect(clickEvent).toBe(false);
+    });
+
+    it('does not activate a disabled slotted anchor on Enter', () => {
+      const childClick = jest.fn();
+      render(
+        <DropdownItem asChild index={0} disabled onClick={mockOnClick}>
+          <a href="/x" onClick={childClick}>
+            Go
+          </a>
+        </DropdownItem>
+      );
+      fireEvent.keyDown(screen.getByRole('menuitem', { name: 'Go' }), { key: 'Enter' });
+      expect(mockOnClick).not.toHaveBeenCalled();
+      expect(childClick).not.toHaveBeenCalled();
+      expect(mockSetOpen).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/tedi/components/overlays/dropdown/dropdown-item/dropdown-item.spec.tsx
+++ b/src/tedi/components/overlays/dropdown/dropdown-item/dropdown-item.spec.tsx
@@ -240,4 +240,70 @@ describe('DropdownItem', () => {
     const item = screen.getByRole('menuitemcheckbox', { name: 'Item' });
     expect(item).toHaveAttribute('aria-checked', 'true');
   });
+
+  describe('asChild slot (navigable child, default closeOnSelect)', () => {
+    it('merges the item props onto the child so the link itself is the single menuitem', () => {
+      render(
+        <DropdownItem asChild index={0}>
+          <a href="/x">Go</a>
+        </DropdownItem>
+      );
+      const item = screen.getByRole('menuitem', { name: 'Go' });
+      expect(item.tagName).toBe('A');
+      expect(item).toHaveAttribute('href', '/x');
+      expect(item).toHaveAttribute('tabindex', '0');
+      expect(item.querySelector('a, button, [tabindex]')).toBeNull();
+    });
+
+    it('runs both the item and child onClick and closes on click', () => {
+      const childClick = jest.fn();
+      render(
+        <DropdownItem asChild index={0} onClick={mockOnClick}>
+          <a href="/x" onClick={childClick}>
+            Go
+          </a>
+        </DropdownItem>
+      );
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Go' }));
+      expect(mockOnClick).toHaveBeenCalledTimes(1);
+      expect(childClick).toHaveBeenCalledTimes(1);
+      expect(mockSetOpen).toHaveBeenCalledWith(false);
+    });
+
+    it('closes on Enter (letting the anchor navigate natively)', () => {
+      render(
+        <DropdownItem asChild index={0} onClick={mockOnClick}>
+          <a href="/x">Go</a>
+        </DropdownItem>
+      );
+      fireEvent.keyDown(screen.getByRole('menuitem', { name: 'Go' }), { key: 'Enter' });
+      expect(mockOnClick).toHaveBeenCalled();
+      expect(mockSetOpen).toHaveBeenCalledWith(false);
+    });
+
+    it('synthesises a click and closes on Space', () => {
+      const childClick = jest.fn();
+      render(
+        <DropdownItem asChild index={0}>
+          <a href="/x" onClick={childClick}>
+            Go
+          </a>
+        </DropdownItem>
+      );
+      fireEvent.keyDown(screen.getByRole('menuitem', { name: 'Go' }), { key: ' ' });
+      expect(childClick).toHaveBeenCalled();
+      expect(mockSetOpen).toHaveBeenCalledWith(false);
+    });
+
+    it('preserves the child className alongside the dropdown item styling', () => {
+      render(
+        <DropdownItem asChild index={0}>
+          <a href="/x" className="my-link">
+            Go
+          </a>
+        </DropdownItem>
+      );
+      expect(screen.getByRole('menuitem', { name: 'Go' })).toHaveClass('my-link');
+    });
+  });
 });

--- a/src/tedi/components/overlays/dropdown/dropdown-item/dropdown-item.tsx
+++ b/src/tedi/components/overlays/dropdown/dropdown-item/dropdown-item.tsx
@@ -6,10 +6,10 @@ import { useDropdownContext } from '../dropdown-context';
 import styles from './dropdown-item.module.scss';
 
 const composeHandlers =
-  <E,>(itemHandler?: (e: E) => void, childHandler?: (e: E) => void) =>
+  <E extends { defaultPrevented: boolean }>(itemHandler?: (e: E) => void, childHandler?: (e: E) => void) =>
   (event: E) => {
     itemHandler?.(event);
-    childHandler?.(event);
+    if (!event.defaultPrevented) childHandler?.(event);
   };
 
 export type DropdownItemProps = {
@@ -132,7 +132,10 @@ export const DropdownItem = ({
   };
 
   const handleClick = (e: React.MouseEvent) => {
-    if (disabled) return; // stop everything
+    if (disabled) {
+      e.preventDefault();
+      return;
+    }
 
     // only trigger inner inputs if not disabled
     const input = (e.currentTarget as HTMLElement).querySelector<HTMLInputElement>(
@@ -151,7 +154,10 @@ export const DropdownItem = ({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (disabled) return;
+    if (disabled) {
+      if (e.key === 'Enter' || e.key === ' ') e.preventDefault();
+      return;
+    }
 
     if (e.key === 'Enter' || e.key === ' ') {
       const input = (e.currentTarget as HTMLElement).querySelector<HTMLInputElement>(
@@ -166,12 +172,8 @@ export const DropdownItem = ({
       }
 
       if (isSlot) {
-        if (e.key === ' ') {
-          e.preventDefault();
-          (e.currentTarget as HTMLElement).click();
-        }
-        onClick?.(e);
-        if (closeOnSelect) setOpen(false);
+        e.preventDefault();
+        (e.currentTarget as HTMLElement).click();
         return;
       }
 
@@ -231,6 +233,8 @@ export const DropdownItem = ({
       ref: slotRef,
       className: cn(merged.className, childProps.className),
       style: { ...merged.style, ...childProps.style },
+      'aria-disabled': disabled || undefined,
+      tabIndex: disabled ? -1 : merged.tabIndex,
       onClick: composeHandlers(merged.onClick, childProps.onClick),
       onKeyDown: composeHandlers(merged.onKeyDown, childProps.onKeyDown),
     });

--- a/src/tedi/components/overlays/dropdown/dropdown-item/dropdown-item.tsx
+++ b/src/tedi/components/overlays/dropdown/dropdown-item/dropdown-item.tsx
@@ -1,7 +1,16 @@
+import { useMergeRefs } from '@floating-ui/react';
 import cn from 'classnames';
+import { cloneElement, isValidElement } from 'react';
 
 import { useDropdownContext } from '../dropdown-context';
 import styles from './dropdown-item.module.scss';
+
+const composeHandlers =
+  <E,>(itemHandler?: (e: E) => void, childHandler?: (e: E) => void) =>
+  (event: E) => {
+    itemHandler?.(event);
+    childHandler?.(event);
+  };
 
 export type DropdownItemProps = {
   /**
@@ -39,10 +48,14 @@ export type DropdownItemProps = {
    */
   indent?: number;
   /**
-   * When `true`, renders a plain `<div>` instead of a `<button>`.
-   * Useful when wrapping form controls like `<Checkbox>` or `<Radio>` that already handle their own events.
-   * **Warning:** When `asChild={true}`, the item is no longer focusable via keyboard navigation
-   * unless the child element itself is focusable.
+   * Render the item as its child element instead of a `<button>`.
+   *
+   * - **Navigable child (default `closeOnSelect`)** — e.g. a `Link`: the item props (`role`,
+   *   roving `tabindex`, handlers, styles) are merged directly onto the child so it becomes the
+   *   single focusable `menuitem`. This avoids a focusable wrapper *and* a focusable child (a
+   *   double Tab stop) and keeps the role and accessible name on one element.
+   * - **Form control (`closeOnSelect={false}`)** — e.g. a `Checkbox` / `Radio`: the child is
+   *   wrapped in a plain `<div>` menuitem that forwards activation to the inner control.
    *
    * @default false
    */
@@ -98,6 +111,15 @@ export const DropdownItem = ({
   const { getItemProps, listItemsRef, setOpen, activeIndex, divided, variant } = useDropdownContext();
 
   const Component = asChild ? 'div' : 'button';
+  const isSlot = asChild && closeOnSelect !== false && isValidElement(children);
+
+  const setItemRef = (node: HTMLElement | null) => {
+    if (typeof index === 'number') {
+      listItemsRef.current[index] = node as HTMLButtonElement | null;
+    }
+  };
+  const childRef = isValidElement(children) ? (children as unknown as { ref?: React.Ref<unknown> }).ref : undefined;
+  const slotRef = useMergeRefs([setItemRef, childRef]);
 
   const getCssVars = (indent?: number): React.CSSProperties => {
     // indent <= 0 means no indentation — leave `--dropdown-indent` unset so the
@@ -121,11 +143,10 @@ export const DropdownItem = ({
       return;
     }
 
-    if (!asChild) {
-      onClick?.(e);
-      if (closeOnSelect) setOpen(false);
-    } else {
-      onClick?.(e);
+    onClick?.(e);
+
+    if ((!asChild || isSlot) && closeOnSelect) {
+      setOpen(false);
     }
   };
 
@@ -133,28 +154,35 @@ export const DropdownItem = ({
     if (disabled) return;
 
     if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-
       const input = (e.currentTarget as HTMLElement).querySelector<HTMLInputElement>(
         'input[type="checkbox"], input[type="radio"]'
       );
 
       if (input) {
+        e.preventDefault();
         input.click();
-      } else {
-        onClick?.(e);
+        if (!asChild && closeOnSelect) setOpen(false);
+        return;
       }
 
+      if (isSlot) {
+        if (e.key === ' ') {
+          e.preventDefault();
+          (e.currentTarget as HTMLElement).click();
+        }
+        onClick?.(e);
+        if (closeOnSelect) setOpen(false);
+        return;
+      }
+
+      e.preventDefault();
+      onClick?.(e);
       if (!asChild && closeOnSelect) setOpen(false);
     }
   };
 
   const baseProps = {
-    ref(node: HTMLElement | null) {
-      if (typeof index === 'number') {
-        listItemsRef.current[index] = node as HTMLButtonElement | null;
-      }
-    },
+    ref: setItemRef,
     tabIndex: activeIndex === index ? 0 : -1,
     className: cn(
       styles['tedi-dropdown__item'],
@@ -182,6 +210,31 @@ export const DropdownItem = ({
           disabled: !asChild ? disabled : undefined,
           ...baseProps,
         });
+
+  if (isSlot) {
+    const child = children as React.ReactElement;
+    const childProps = child.props as {
+      className?: string;
+      style?: React.CSSProperties;
+      onClick?: (e: React.MouseEvent) => void;
+      onKeyDown?: (e: React.KeyboardEvent) => void;
+    };
+    const merged = itemProps as typeof itemProps & {
+      className?: string;
+      style?: React.CSSProperties;
+      onClick?: (e: React.MouseEvent) => void;
+      onKeyDown?: (e: React.KeyboardEvent) => void;
+    };
+
+    return cloneElement(child, {
+      ...merged,
+      ref: slotRef,
+      className: cn(merged.className, childProps.className),
+      style: { ...merged.style, ...childProps.style },
+      onClick: composeHandlers(merged.onClick, childProps.onClick),
+      onKeyDown: composeHandlers(merged.onKeyDown, childProps.onKeyDown),
+    });
+  }
 
   return <Component {...itemProps}>{children}</Component>;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dropdown items can now render as navigable child elements, such as links, while preserving their attributes and styling.
  * Added consistent click, Enter, and Space activation behavior for linked dropdown items.
  * Dropdown menus now close appropriately after selection, including interactions with nested checkbox and radio controls.
* **Bug Fixes**
  * Improved breadcrumb overflow menus so collapsed items expose correctly structured, usable links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->