### PR TITLE
feat(helpers): export polymorphic type helpers for extensibility #200

### DIFF
--- a/skills/tedi-react/references/components.md
+++ b/skills/tedi-react/references/components.md
@@ -1957,3 +1957,41 @@ Data-driven legacy footer (`categories` array + `logo` + `bottomElement`). Respo
 ### Map Components
 
 14 specialized components for map UI interactions (BaseMapSelection, Legend, MapLayer, Directions, Timeline, etc.)
+
+## Extending components
+
+TEDI exports a few type helpers so you can build **custom or extended** components
+that match its patterns, without deep relative imports.
+
+**Polymorphic (`as` prop) components** — reuse TEDI's polymorphic types:
+
+```tsx
+import { forwardRef } from 'react';
+import { PolymorphicComponentPropWithRef, PolymorphicRef } from '@tedi-design-system/react/tedi';
+
+type MyBoxProps<C extends React.ElementType> = PolymorphicComponentPropWithRef<C, { muted?: boolean }>;
+
+const MyBox = forwardRef(
+  <C extends React.ElementType = 'div'>({ as, muted, ...rest }: MyBoxProps<C>, ref: PolymorphicRef<C>) => {
+    const Tag = as ?? 'div';
+    return <Tag ref={ref} data-muted={muted} {...rest} />;
+  }
+);
+```
+
+Also available: `PolymorphicComponentPropWithoutRef`, and `AllowedHTMLTags<C, Allowed>` to constrain `as` to specific tags.
+
+**Responsive props** — `BreakpointSupport<T>` + `useBreakpointProps` let a custom component accept per-breakpoint prop overrides the same way TEDI components do:
+
+```tsx
+import { BreakpointSupport, useBreakpointProps } from '@tedi-design-system/react/tedi';
+
+type Props = BreakpointSupport<{ size?: 'sm' | 'lg' }>;
+
+const MyResponsive = (props: Props) => {
+  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { size = 'sm' } = getCurrentBreakpointProps<Props>(props);
+  return <div data-size={size} />;
+};
+// <MyResponsive size="sm" md={{ size: 'lg' }} />
+```

--- a/skills/tedi-react/references/components.md
+++ b/skills/tedi-react/references/components.md
@@ -1966,17 +1966,25 @@ that match its patterns, without deep relative imports.
 **Polymorphic (`as` prop) components** — reuse TEDI's polymorphic types:
 
 ```tsx
-import { forwardRef } from 'react';
+import React, { forwardRef } from 'react';
 import { PolymorphicComponentPropWithRef, PolymorphicRef } from '@tedi-design-system/react/tedi';
 
-type MyBoxProps<C extends React.ElementType> = PolymorphicComponentPropWithRef<C, { muted?: boolean }>;
+type MyBoxProps<C extends React.ElementType = 'div'> = PolymorphicComponentPropWithRef<C, { muted?: boolean }>;
 
-const MyBox = forwardRef(
-  <C extends React.ElementType = 'div'>({ as, muted, ...rest }: MyBoxProps<C>, ref: PolymorphicRef<C>) => {
-    const Tag = as ?? 'div';
+const MyBoxInner = forwardRef(
+  <C extends React.ElementType = 'div'>({ as, muted, ...rest }: MyBoxProps<C>, ref?: PolymorphicRef<C>): JSX.Element => {
+    const Tag: React.ElementType = as ?? 'div';
     return <Tag ref={ref} data-muted={muted} {...rest} />;
   }
 );
+
+MyBoxInner.displayName = 'MyBox';
+
+// Cast to a generic call signature so `as`-specific props (e.g. `href` when
+// `as="a"`) are inferred — assigning forwardRef directly loses the generic.
+export const MyBox = MyBoxInner as <C extends React.ElementType = 'div'>(
+  props: MyBoxProps<C>
+) => React.ReactElement | null;
 ```
 
 Also available: `PolymorphicComponentPropWithoutRef`, and `AllowedHTMLTags<C, Allowed>` to constrain `as` to specific tags.

--- a/src/tedi/helpers/index.ts
+++ b/src/tedi/helpers/index.ts
@@ -7,3 +7,6 @@ export * from './hooks/use-is-touch-device';
 export * from './hooks/use-file-upload';
 export * from './hooks/use-what-input';
 export * from './hooks/use-scroll-fade';
+
+// Type helpers for building custom / extended polymorphic components (issue #200).
+export * from './polymorphic/types';

--- a/src/tedi/helpers/polymorphic/types.ts
+++ b/src/tedi/helpers/polymorphic/types.ts
@@ -1,5 +1,10 @@
 /**
- * This file should contain only helpers that are used for developing components. They don't get exported separately from component library
+ * Type helpers for building polymorphic components (the `as` prop pattern).
+ *
+ * These are part of the public API (re-exported from the package root via
+ * `helpers`) so consumers can build custom or extended components that match
+ * TEDI's polymorphic typing without deep relative imports. Treat them as a
+ * stable, advanced/extension API. See issue #200.
  */
 import React from 'react';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed polymorphic component type helpers through the public API.
  * Added support documentation and examples for extending components with polymorphic and responsive properties.

* **Documentation**
  * Documented advanced helpers for forwarded refs, breakpoint-aware props, and responsive property handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->