### PR TITLE
fix(overlay,map-button,button-group): tooltip stuck open, dropdownItems isActive drop, className overwrite #837

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,10 @@ migrations.json
 # Generated a11y report (CI)
 a11y-report/
 
+# Claude working docs (research/plan phase)
+/research.md
+/plan.md
+
 # design-sync (claude.ai/design import)
 .design-sync/sb-reference/
 .design-sync/learnings/

--- a/.gitignore
+++ b/.gitignore
@@ -60,10 +60,6 @@ migrations.json
 # Generated a11y report (CI)
 a11y-report/
 
-# Claude working docs (research/plan phase)
-/research.md
-/plan.md
-
 # design-sync (claude.ai/design import)
 .design-sync/sb-reference/
 .design-sync/learnings/

--- a/src/community/components/map-components/button-group/button-group.spec.tsx
+++ b/src/community/components/map-components/button-group/button-group.spec.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+// The `src/tedi` barrel transitively imports react-sticky-box (ESM-only), which Jest does not transform.
+jest.mock('react-sticky-box', () => ({ __esModule: true, default: () => null }));
+
+import { MapButton } from '../map-button/map-button';
+import { ButtonGroup } from './button-group';
+
+describe('ButtonGroup', () => {
+  it('renders MapButton children', () => {
+    render(
+      <ButtonGroup ariaLabel="Group">
+        <MapButton id="a">A</MapButton>
+        <MapButton id="b">B</MapButton>
+      </ButtonGroup>
+    );
+
+    expect(screen.getByRole('button', { name: 'A' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'B' })).toBeInTheDocument();
+  });
+
+  it('applies active and disabled modifier classes based on child props', () => {
+    render(
+      <ButtonGroup ariaLabel="Group">
+        <MapButton id="a" isActive>
+          A
+        </MapButton>
+        <MapButton id="b" disabled>
+          B
+        </MapButton>
+      </ButtonGroup>
+    );
+
+    expect(screen.getByRole('button', { name: 'A' }).className).toContain('tedi-button-group__item--active');
+    expect(screen.getByRole('button', { name: 'B' }).className).toContain('tedi-button-group__item--disabled');
+  });
+
+  it('keeps a custom className on a child alongside the group-injected classes', () => {
+    render(
+      <ButtonGroup ariaLabel="Group">
+        <MapButton id="a" className="custom-class">
+          A
+        </MapButton>
+      </ButtonGroup>
+    );
+
+    const button = screen.getByRole('button', { name: 'A' });
+    expect(button.className).toContain('tedi-button-group__item');
+    expect(button.className).toContain('custom-class');
+  });
+
+  it('fires both the child onClick and onSelectionChange', () => {
+    const onClick = jest.fn();
+    const onSelectionChange = jest.fn();
+
+    render(
+      <ButtonGroup ariaLabel="Group" onSelectionChange={onSelectionChange}>
+        <MapButton id="a" onClick={onClick}>
+          A
+        </MapButton>
+      </ButtonGroup>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'A' }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onSelectionChange).toHaveBeenCalledWith('a');
+  });
+
+  it('does not fire onClick or onSelectionChange when the child is disabled', () => {
+    const onClick = jest.fn();
+    const onSelectionChange = jest.fn();
+
+    render(
+      <ButtonGroup ariaLabel="Group" onSelectionChange={onSelectionChange}>
+        <MapButton id="a" disabled onClick={onClick}>
+          A
+        </MapButton>
+      </ButtonGroup>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'A' }));
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(onSelectionChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/community/components/map-components/button-group/button-group.tsx
+++ b/src/community/components/map-components/button-group/button-group.tsx
@@ -91,10 +91,14 @@ export const ButtonGroup = (props: ButtonGroupProps): JSX.Element => {
         if (isValidElement(child) && child.type === MapButton) {
           const typedChild = child as React.ReactElement<MapButtonProps>;
           return cloneElement(typedChild, {
-            className: cn(styles['tedi-button-group__item'], {
-              [styles['tedi-button-group__item--active']]: typedChild.props.isActive,
-              [styles['tedi-button-group__item--disabled']]: typedChild.props.disabled,
-            }),
+            className: cn(
+              styles['tedi-button-group__item'],
+              {
+                [styles['tedi-button-group__item--active']]: typedChild.props.isActive,
+                [styles['tedi-button-group__item--disabled']]: typedChild.props.disabled,
+              },
+              typedChild.props.className
+            ),
             onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
               if (!typedChild.props.disabled) {
                 typedChild.props.onClick?.(event);

--- a/src/community/components/map-components/map-button/map-button.spec.tsx
+++ b/src/community/components/map-components/map-button/map-button.spec.tsx
@@ -47,4 +47,23 @@ describe('MapButton', () => {
     rerender(<MapButton isActive>Text</MapButton>);
     expect(screen.getByRole('button').className).toContain('tedi-map-button--is-active');
   });
+
+  it('forwards isActive to dropdownItems so the active option is highlighted', () => {
+    render(
+      <MapButton
+        dropdownItems={[
+          { children: 'Option A', isActive: false },
+          { children: 'Option B', isActive: true },
+        ]}
+      >
+        Text
+      </MapButton>
+    );
+
+    fireEvent.click(screen.getByRole('combobox'));
+
+    const options = screen.getAllByRole('option');
+    expect(options[0].className).not.toContain('tedi-map-dropdown__item--active');
+    expect(options[1].className).toContain('tedi-map-dropdown__item--active');
+  });
 });

--- a/src/community/components/map-components/map-button/map-button.spec.tsx
+++ b/src/community/components/map-components/map-button/map-button.spec.tsx
@@ -65,5 +65,9 @@ describe('MapButton', () => {
     const options = screen.getAllByRole('option');
     expect(options[0].className).not.toContain('tedi-map-dropdown__item--active');
     expect(options[1].className).toContain('tedi-map-dropdown__item--active');
+
+    // Keyboard navigation should also initialize from the active item (roving tabIndex).
+    expect(options[0]).toHaveAttribute('tabindex', '-1');
+    expect(options[1]).toHaveAttribute('tabindex', '0');
   });
 });

--- a/src/community/components/map-components/map-button/map-button.tsx
+++ b/src/community/components/map-components/map-button/map-button.tsx
@@ -121,6 +121,7 @@ export const MapButton = (props: MapButtonProps): JSX.Element => {
           items={dropdownItems.map((item) => ({
             children: item.children,
             onClick: item.onClick,
+            isActive: item.isActive,
             isDisabled: item.isDisabled,
           }))}
         />

--- a/src/tedi/components/overlays/overlay/overlay.spec.tsx
+++ b/src/tedi/components/overlays/overlay/overlay.spec.tsx
@@ -154,7 +154,7 @@ describe('Overlay component', () => {
     await act(async () => {
       fireEvent.mouseEnter(trigger);
     });
-    expect(screen.getByTestId('overlay-content')).toBeInTheDocument();
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(trigger);
@@ -163,7 +163,7 @@ describe('Overlay component', () => {
       fireEvent.mouseLeave(trigger);
     });
 
-    expect(screen.queryByTestId('overlay-content')).not.toBeInTheDocument();
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
 
   describe('Overlay scroll locking', () => {

--- a/src/tedi/components/overlays/overlay/overlay.spec.tsx
+++ b/src/tedi/components/overlays/overlay/overlay.spec.tsx
@@ -37,7 +37,7 @@ describe('Overlay component', () => {
     expect(trigger).toHaveClass('tedi-overlay__trigger--text');
     expect(trigger).toHaveClass('custom-class');
 
-    fireEvent.click(trigger);
+    fireEvent.mouseEnter(trigger);
     const content = screen.getByTestId('overlay-content');
     const arrow = screen.getByTestId('overlay-arrow');
 
@@ -131,7 +131,7 @@ describe('Overlay component', () => {
     const onToggleMock = jest.fn();
 
     render(
-      <Overlay open={false} onToggle={onToggleMock}>
+      <Overlay open={false} onToggle={onToggleMock} openWith="click">
         <Overlay.Trigger>Trigger</Overlay.Trigger>
         <Overlay.Content>Content</Overlay.Content>
       </Overlay>
@@ -139,6 +139,31 @@ describe('Overlay component', () => {
 
     fireEvent.click(screen.getByText('Trigger'));
     expect(onToggleMock).toHaveBeenCalledWith(true);
+  });
+
+  it('does not stay open after a click while hovering (hover mode)', async () => {
+    render(
+      <Overlay>
+        <Overlay.Trigger>Trigger</Overlay.Trigger>
+        <Overlay.Content>Content</Overlay.Content>
+      </Overlay>
+    );
+
+    const trigger = screen.getByText('Trigger');
+
+    await act(async () => {
+      fireEvent.mouseEnter(trigger);
+    });
+    expect(screen.getByTestId('overlay-content')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(trigger);
+    });
+    await act(async () => {
+      fireEvent.mouseLeave(trigger);
+    });
+
+    expect(screen.queryByTestId('overlay-content')).not.toBeInTheDocument();
   });
 
   describe('Overlay scroll locking', () => {

--- a/src/tedi/components/overlays/overlay/overlay.tsx
+++ b/src/tedi/components/overlays/overlay/overlay.tsx
@@ -245,6 +245,7 @@ export const Overlay = (props: OverlayProps) => {
       handleClose: safePolygon(),
     }),
     useClick(context, {
+      enabled: openWith === 'click',
       toggle: dismissible,
     }),
     useFocus(context, {


### PR DESCRIPTION
Closes #837

Fixes the tooltip stuck-open, `dropdownItems` isActive drop, and ButtonGroup className
overwrite issues from #837. The "isHovered/isActive/selected render the same background
color" item is not addressed here (design-token question, not tracked further as part of
this fix).

Three independent MapButton-family fixes:

- **overlay**: `useClick` was wired up unconditionally instead of being gated by
  `openWith === 'click'` like `useHover`/`useFocus` already are. Floating UI's `useClick`
  defaults `stickIfOpen: true`, so clicking a hover-mode tooltip trigger (e.g. MapButton)
  while it's already open re-attributes the open state to the click, and a plain mouse-leave
  no longer closes it — the tooltip stays stuck open after a press.
- **map-button**: `dropdownItems` mapped into `MapDropdown.Content`'s `items` prop without
  forwarding `isActive`, so the active dropdown entry was never highlighted and never became
  the initial keyboard-navigation selection.
- **button-group**: `cloneElement` replaced a `MapButton` child's `className` outright instead
  of merging it, silently dropping any custom class a consumer added.

Each fix has test coverage (one pre-existing overlay test updated since it relied on the buggy
click-always-on behavior; a new `button-group.spec.tsx` was added since none existed).
