### PR TITLE
feat(list): add start prop #620

### DIFF
--- a/skills/tedi-react/references/components.md
+++ b/skills/tedi-react/references/components.md
@@ -388,7 +388,7 @@ import { Carousel } from '@tedi-design-system/react/tedi';
 - `element: 'ul' | 'ol' = 'ul'`
 - `style: 'styled' | 'none' = 'none'`
 - `color: BulletColor = 'brand'`
-- Forwards native list attributes to the element (`OlHTMLAttributes`) — notably `start` / `reversed` for ordered lists, plus `id` / `aria-*`. `style` is not forwarded (repurposed for the styling variant). `start` visibly reseeds the numbering (the numbers are a CSS counter, so `List` sets `counter-reset` from it).
+- Forwards native list attributes to the element (`OlHTMLAttributes`) — notably `start` / `reversed` for ordered lists, plus `id` / `aria-*`. `style` is not forwarded (repurposed for the styling variant). The numbers are a CSS counter, so `List` reseeds it: `start` sets the first number, and `reversed` counts down (from `start`, or the item count when `start` is omitted).
 
 Sub-component: `List.Item` — forwards native `<li>` attributes; `value` overrides a single item's number in an ordered list (`5, 6, 10, 11`). `value` needs Safari 17.2+ to reseed the visible counter; older browsers keep sequential numbering.
 

--- a/skills/tedi-react/references/components.md
+++ b/skills/tedi-react/references/components.md
@@ -388,8 +388,9 @@ import { Carousel } from '@tedi-design-system/react/tedi';
 - `element: 'ul' | 'ol' = 'ul'`
 - `style: 'styled' | 'none' = 'none'`
 - `color: BulletColor = 'brand'`
+- Forwards native list attributes to the element (`OlHTMLAttributes`) — notably `start` / `reversed` for ordered lists, plus `id` / `aria-*`. `style` is not forwarded (repurposed for the styling variant). `start` visibly reseeds the numbering (the numbers are a CSS counter, so `List` sets `counter-reset` from it).
 
-Sub-component: `List.Item`
+Sub-component: `List.Item` — forwards native `<li>` attributes; `value` overrides a single item's number in an ordered list (`5, 6, 10, 11`). `value` needs Safari 17.2+ to reseed the visible counter; older browsers keep sequential numbering.
 
 ### Section
 

--- a/src/tedi/components/content/list/list-item.tsx
+++ b/src/tedi/components/content/list/list-item.tsx
@@ -12,7 +12,12 @@ type ListItemBreakpointProps = {
   verticalSpacingItem?: Omit<VerticalSpacingItemProps, 'element' | 'children'>;
 };
 
-export interface ListItemProps extends BreakpointSupport<ListItemBreakpointProps> {
+export interface ListItemProps
+  extends BreakpointSupport<ListItemBreakpointProps>,
+    // Forward native `<li>` attributes — notably `value` to override a single
+    // item's number in an ordered list, plus `id` / `aria-*`. `style` is omitted
+    // for parity with `List`.
+    Omit<React.LiHTMLAttributes<HTMLLIElement>, 'style' | 'children'> {
   /**
    * List children should be ListItem components
    */
@@ -25,18 +30,34 @@ export interface ListItemProps extends BreakpointSupport<ListItemBreakpointProps
 
 export const ListItem = (props: ListItemProps) => {
   const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
-  const { children, verticalSpacingItem, className } = getCurrentBreakpointProps<ListItemProps>(props);
+  const { children, verticalSpacingItem, className, ...rest } = getCurrentBreakpointProps<ListItemProps>(props);
   const listItemBEM = cn(styles['tedi-list__item'], verticalSpacingItem?.className, className);
 
+  // In an ordered list the number is a CSS counter, so `value` (override this
+  // item's number) only shows if we set the counter. Use `counter-set`, not
+  // `counter-reset` — reset would open a *new* nested counter scope, which
+  // `counters(item, '.')` then renders as e.g. "6.10". We also switch off this
+  // item's own increment so the value is exact regardless of the set/increment
+  // order; following items continue from it. (`counter-set` needs Safari 17.2+;
+  // older browsers fall back to normal numbering.)
+  const itemStyle =
+    typeof rest.value === 'number' ? { counterIncrement: 'none', counterSet: `item ${rest.value}` } : undefined;
+
   if (props.verticalSpacingItem) {
+    // `VerticalSpacingItem` owns the element's `style`; `value` still forwards to
+    // the DOM but won't reseed the visible number in this composition.
     return (
-      <VerticalSpacingItem {...verticalSpacingItem} element="li" className={listItemBEM}>
+      <VerticalSpacingItem {...verticalSpacingItem} {...rest} element="li" className={listItemBEM}>
         {children}
       </VerticalSpacingItem>
     );
   }
 
-  return <li className={listItemBEM}>{children}</li>;
+  return (
+    <li className={listItemBEM} {...rest} style={itemStyle}>
+      {children}
+    </li>
+  );
 };
 
 export default ListItem;

--- a/src/tedi/components/content/list/list-item.tsx
+++ b/src/tedi/components/content/list/list-item.tsx
@@ -44,10 +44,9 @@ export const ListItem = (props: ListItemProps) => {
     typeof rest.value === 'number' ? { counterIncrement: 'none', counterSet: `item ${rest.value}` } : undefined;
 
   if (props.verticalSpacingItem) {
-    // `VerticalSpacingItem` owns the element's `style`; `value` still forwards to
-    // the DOM but won't reseed the visible number in this composition.
+    // `VerticalSpacingItem` merges the counter override with its own spacing style.
     return (
-      <VerticalSpacingItem {...verticalSpacingItem} {...rest} element="li" className={listItemBEM}>
+      <VerticalSpacingItem {...verticalSpacingItem} {...rest} element="li" className={listItemBEM} style={itemStyle}>
         {children}
       </VerticalSpacingItem>
     );

--- a/src/tedi/components/content/list/list.module.scss
+++ b/src/tedi/components/content/list/list.module.scss
@@ -84,6 +84,10 @@ $bullet-colors: (
   }
 }
 
+.tedi-list--ordered.tedi-list--reversed > .tedi-list__item {
+  counter-increment: item -1;
+}
+
 .tedi-list--style-none {
   padding: 0;
   list-style: none;

--- a/src/tedi/components/content/list/list.spec.tsx
+++ b/src/tedi/components/content/list/list.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { useBreakpointProps } from '../../../helpers';
 import List, { ListProps } from './list';
@@ -59,29 +59,55 @@ describe('List Component', () => {
   });
 
   test('forwards the "start" attribute and seeds the CSS counter so numbering begins at it', () => {
-    const { container } = renderList({ element: 'ol', start: 5 });
-    const ol = container.querySelector('ol');
+    renderList({ element: 'ol', start: 5 });
+    const ol = screen.getByRole('list');
     expect(ol).toHaveAttribute('start', '5');
     expect(ol).toHaveStyle({ counterReset: 'item 4' });
   });
 
   test('forwards native attributes (id, aria-label, reversed) to the list element', () => {
-    const { container } = renderList({ element: 'ol', id: 'steps', 'aria-label': 'Steps', reversed: true });
-    const ol = container.querySelector('ol');
+    renderList({ element: 'ol', id: 'steps', 'aria-label': 'Steps', reversed: true });
+    const ol = screen.getByRole('list', { name: 'Steps' });
     expect(ol).toHaveAttribute('id', 'steps');
-    expect(ol).toHaveAttribute('aria-label', 'Steps');
     expect(ol).toHaveAttribute('reversed');
   });
 
+  test('counts a reversed ordered list down, seeding from the item count', () => {
+    renderList({ element: 'ol', reversed: true });
+    const ol = screen.getByRole('list');
+    expect(ol).toHaveClass('tedi-list--reversed');
+    expect(ol).toHaveStyle({ counterReset: 'item 4' });
+  });
+
+  test('reversed ordered list honours an explicit start', () => {
+    renderList({ element: 'ol', reversed: true, start: 5 });
+    expect(screen.getByRole('list')).toHaveStyle({ counterReset: 'item 6' });
+  });
+
+  test('seeds the counter through the verticalSpacing wrapper', () => {
+    const { container } = renderList({ element: 'ol', start: 5, verticalSpacing: { size: 1 } });
+    expect(container.querySelector('ol')).toHaveStyle({ counterReset: 'item 4' });
+  });
+
+  test('applies the value counter override through the verticalSpacingItem wrapper', () => {
+    render(
+      <List element="ol">
+        <ListItem verticalSpacingItem={{ size: 1 }} value={10}>
+          Item
+        </ListItem>
+      </List>
+    );
+    expect(screen.getByRole('listitem')).toHaveStyle({ counterSet: 'item 10', counterIncrement: 'none' });
+  });
+
   test('forwards the "value" attribute on a ListItem and seeds the counter to that number', () => {
-    const { container } = render(
+    render(
       <List element="ol">
         <ListItem value={10}>Item</ListItem>
       </List>
     );
-    const li = container.querySelector('li');
+    const li = screen.getByRole('listitem');
     expect(li).toHaveAttribute('value', '10');
-    // Set the counter (no new scope) and drop the increment so the number is exact.
     expect(li).toHaveStyle({ counterSet: 'item 10', counterIncrement: 'none' });
   });
 

--- a/src/tedi/components/content/list/list.spec.tsx
+++ b/src/tedi/components/content/list/list.spec.tsx
@@ -58,6 +58,33 @@ describe('List Component', () => {
     expect(container.firstChild).toHaveClass('tedi-list--bullet-color-brand');
   });
 
+  test('forwards the "start" attribute and seeds the CSS counter so numbering begins at it', () => {
+    const { container } = renderList({ element: 'ol', start: 5 });
+    const ol = container.querySelector('ol');
+    expect(ol).toHaveAttribute('start', '5');
+    expect(ol).toHaveStyle({ counterReset: 'item 4' });
+  });
+
+  test('forwards native attributes (id, aria-label, reversed) to the list element', () => {
+    const { container } = renderList({ element: 'ol', id: 'steps', 'aria-label': 'Steps', reversed: true });
+    const ol = container.querySelector('ol');
+    expect(ol).toHaveAttribute('id', 'steps');
+    expect(ol).toHaveAttribute('aria-label', 'Steps');
+    expect(ol).toHaveAttribute('reversed');
+  });
+
+  test('forwards the "value" attribute on a ListItem and seeds the counter to that number', () => {
+    const { container } = render(
+      <List element="ol">
+        <ListItem value={10}>Item</ListItem>
+      </List>
+    );
+    const li = container.querySelector('li');
+    expect(li).toHaveAttribute('value', '10');
+    // Set the counter (no new scope) and drop the increment so the number is exact.
+    expect(li).toHaveStyle({ counterSet: 'item 10', counterIncrement: 'none' });
+  });
+
   test.each([
     'primary',
     'secondary',

--- a/src/tedi/components/content/list/list.stories.tsx
+++ b/src/tedi/components/content/list/list.stories.tsx
@@ -142,6 +142,28 @@ export const OrderedList: Story = {
   },
 };
 
+/**
+ * `start` begins the numbering at a given value, and a single `List.Item` can
+ * override its own number with `value` (following items continue from there).
+ * This example starts at **5** and jumps the third item to **10**, so it renders
+ * `5, 6, 10, 11`. The numbers are drawn with a CSS counter, so `List` seeds that
+ * counter from `start` / `value` (the native attributes are also forwarded).
+ */
+export const OrderedListWithStart: Story = {
+  name: 'Ordered list with start / value',
+  render: (args) => (
+    <List {...args} element="ol" start={5}>
+      <List.Item>Starts at five</List.Item>
+      <List.Item>Six</List.Item>
+      <List.Item value={10}>Jumps to ten</List.Item>
+      <List.Item>Eleven</List.Item>
+    </List>
+  ),
+  args: {
+    style: 'styled',
+  },
+};
+
 export const NoStyleList: Story = {
   render: TemplateNoStyleList,
   args: {

--- a/src/tedi/components/content/list/list.stories.tsx
+++ b/src/tedi/components/content/list/list.stories.tsx
@@ -164,6 +164,25 @@ export const OrderedListWithStart: Story = {
   },
 };
 
+/**
+ * `reversed` counts the list down. With no `start` it begins at the item count
+ * (here `3, 2, 1`); pass `start` to begin elsewhere. The numbers are a CSS
+ * counter, so `List` applies a descending increment and seeds the first value.
+ */
+export const ReversedOrderedList: Story = {
+  name: 'Reversed ordered list',
+  render: (args) => (
+    <List {...args} element="ol" reversed>
+      <List.Item>Third</List.Item>
+      <List.Item>Second</List.Item>
+      <List.Item>First</List.Item>
+    </List>
+  ),
+  args: {
+    style: 'styled',
+  },
+};
+
 export const NoStyleList: Story = {
   render: TemplateNoStyleList,
   args: {

--- a/src/tedi/components/content/list/list.tsx
+++ b/src/tedi/components/content/list/list.tsx
@@ -1,4 +1,5 @@
 import cn from 'classnames';
+import { Children } from 'react';
 
 import { BreakpointSupport, useBreakpointProps } from '../../../helpers';
 import { IconColor } from '../../base/icon/icon';
@@ -62,30 +63,36 @@ export const List = (props: ListProps) => {
     color = 'brand',
     ...rest
   } = getCurrentBreakpointProps<ListProps>(props);
+  const isReversedOrdered = element === 'ol' && rest.reversed === true;
   const listBEM = cn(
     styles['tedi-list'],
     styles[`tedi-list--${element === 'ul' ? 'unordered' : 'ordered'}`],
     styles[`tedi-list--style-${style}`],
     styles[`tedi-list--bullet-color-${color}`],
+    isReversedOrdered && styles['tedi-list--reversed'],
     verticalSpacing?.className,
     className
   );
   const Element = element;
 
   // The visible numbers come from a CSS counter, not the native `<ol>` marker, so
-  // `start` only takes effect if we seed that counter. `counter-reset` is
-  // processed before `counter-increment`, so resetting to `start - 1` makes the
-  // first item render as `start`. (The native `start` attribute is still
-  // forwarded for correct semantics / copy-paste / non-CSS fallback.)
-  const orderedListStyle =
-    element === 'ol' && typeof rest.start === 'number' ? { counterReset: `item ${rest.start - 1}` } : undefined;
+  // `start` / `reversed` only take effect if we seed that counter (the native
+  // attributes are still forwarded for correct semantics / copy-paste / non-CSS
+  // fallback). `counter-reset` is processed before `counter-increment`.
+  const orderedListStyle = (() => {
+    if (element !== 'ol') return undefined;
+    if (isReversedOrdered) {
+      const first = typeof rest.start === 'number' ? rest.start : Children.count(children);
+      return { counterReset: `item ${first + 1}` };
+    }
+
+    return typeof rest.start === 'number' ? { counterReset: `item ${rest.start - 1}` } : undefined;
+  })();
 
   if (verticalSpacing) {
-    // `VerticalSpacing` owns the element's `style`, so the counter seed can't be
-    // applied here — `start` still forwards to the DOM but won't reseed the visible
-    // numbering in this (uncommon) composition.
+    // `VerticalSpacing` merges the counter seed with its own spacing style.
     return (
-      <VerticalSpacing {...verticalSpacing} {...rest} element={element} className={listBEM}>
+      <VerticalSpacing {...verticalSpacing} {...rest} element={element} className={listBEM} style={orderedListStyle}>
         {children}
       </VerticalSpacing>
     );

--- a/src/tedi/components/content/list/list.tsx
+++ b/src/tedi/components/content/list/list.tsx
@@ -23,7 +23,12 @@ type ListBreakpointProps = {
   style?: 'styled' | 'none';
 };
 
-export interface ListProps extends BreakpointSupport<ListBreakpointProps> {
+export interface ListProps
+  extends BreakpointSupport<ListBreakpointProps>,
+    // Forward native list attributes to the rendered element — notably `start`,
+    // `reversed` and `type` for ordered lists, plus `id` / `aria-*`. `style` is
+    // omitted because this component repurposes it for the styling variant.
+    Omit<React.OlHTMLAttributes<HTMLOListElement>, 'style' | 'children'> {
   /**
    * List children should be ListItem components
    */
@@ -55,6 +60,7 @@ export const List = (props: ListProps) => {
     verticalSpacing,
     className,
     color = 'brand',
+    ...rest
   } = getCurrentBreakpointProps<ListProps>(props);
   const listBEM = cn(
     styles['tedi-list'],
@@ -66,15 +72,30 @@ export const List = (props: ListProps) => {
   );
   const Element = element;
 
+  // The visible numbers come from a CSS counter, not the native `<ol>` marker, so
+  // `start` only takes effect if we seed that counter. `counter-reset` is
+  // processed before `counter-increment`, so resetting to `start - 1` makes the
+  // first item render as `start`. (The native `start` attribute is still
+  // forwarded for correct semantics / copy-paste / non-CSS fallback.)
+  const orderedListStyle =
+    element === 'ol' && typeof rest.start === 'number' ? { counterReset: `item ${rest.start - 1}` } : undefined;
+
   if (verticalSpacing) {
+    // `VerticalSpacing` owns the element's `style`, so the counter seed can't be
+    // applied here — `start` still forwards to the DOM but won't reseed the visible
+    // numbering in this (uncommon) composition.
     return (
-      <VerticalSpacing {...verticalSpacing} element={element} className={listBEM}>
+      <VerticalSpacing {...verticalSpacing} {...rest} element={element} className={listBEM}>
         {children}
       </VerticalSpacing>
     );
   }
 
-  return <Element className={listBEM}>{children}</Element>;
+  return (
+    <Element className={listBEM} {...rest} style={orderedListStyle}>
+      {children}
+    </Element>
+  );
 };
 
 List.Item = ListItem;

--- a/src/tedi/components/layout/vertical-spacing/vertical-spacing-item.tsx
+++ b/src/tedi/components/layout/vertical-spacing/vertical-spacing-item.tsx
@@ -26,6 +26,11 @@ export interface VerticalSpacingItemProps extends BreakpointSupport<VerticalSpac
    * Additional class name(s) to apply to the element
    */
   className?: string;
+  /**
+   * Additional inline styles, merged with the internal spacing custom property
+   * (rather than replacing it).
+   */
+  style?: React.CSSProperties;
 }
 
 export const VerticalSpacingItem = (props: VerticalSpacingItemProps): JSX.Element => {
@@ -35,6 +40,7 @@ export const VerticalSpacingItem = (props: VerticalSpacingItemProps): JSX.Elemen
     className,
     element: Element = 'div',
     size = 1,
+    style,
     ...rest
   } = getCurrentBreakpointProps<VerticalSpacingItemProps>(props);
 
@@ -44,7 +50,7 @@ export const VerticalSpacingItem = (props: VerticalSpacingItemProps): JSX.Elemen
     <Element
       data-name="vertical-spacing-item"
       {...rest}
-      style={{ '--vertical-spacing-internal': `${size}${size !== 0 ? 'em' : ''}` }}
+      style={{ '--vertical-spacing-internal': `${size}${size !== 0 ? 'em' : ''}`, ...style }}
       className={VerticalSpacingItemBEM}
     >
       {children}

--- a/src/tedi/components/layout/vertical-spacing/vertical-spacing.stories.tsx
+++ b/src/tedi/components/layout/vertical-spacing/vertical-spacing.stories.tsx
@@ -97,7 +97,9 @@ const MixedContentTemplate: StoryFn<VerticalSpacingProps> = (args) => (
   <VerticalSpacing {...args}>
     <Heading element="h1">Mixed Content Example</Heading>
     <Text>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam pretium lacinia urna in efficitur.</Text>
-    <Heading element="h4">Mixed Content Example</Heading>
+    <Heading element="h2" modifiers="h4">
+      Mixed Content Example
+    </Heading>
     <img width={200} src="tehik_logo.png" alt="tehik.ee" />
     <Text>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam pretium lacinia urna in efficitur.</Text>
     <Icon name="home" />

--- a/src/tedi/components/layout/vertical-spacing/vertical-spacing.tsx
+++ b/src/tedi/components/layout/vertical-spacing/vertical-spacing.tsx
@@ -29,6 +29,11 @@ export interface VerticalSpacingProps extends BreakpointSupport<VerticalSpacingB
    * Additional class name(s) to apply to the element
    */
   className?: string;
+  /**
+   * Additional inline styles, merged with the internal spacing custom property
+   * (rather than replacing it).
+   */
+  style?: React.CSSProperties;
 }
 
 export const VerticalSpacing = (props: VerticalSpacingProps): JSX.Element => {
@@ -38,6 +43,7 @@ export const VerticalSpacing = (props: VerticalSpacingProps): JSX.Element => {
     className,
     element: Element = 'div',
     size = 1,
+    style,
     ...rest
   } = getCurrentBreakpointProps<VerticalSpacingProps>(props);
 
@@ -49,7 +55,7 @@ export const VerticalSpacing = (props: VerticalSpacingProps): JSX.Element => {
       role="presentation"
       {...rest}
       className={VerticalSpacingBEM}
-      style={{ '--vertical-spacing-internal': size !== 0 ? `${size}em` : '0' }}
+      style={{ '--vertical-spacing-internal': size !== 0 ? `${size}em` : '0', ...style }}
     >
       {children}
     </Element>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ordered lists now support native attributes such as `start` and `reversed`.
  * List items support native attributes, including custom ordered-list values.
  * Ordered-list numbering correctly reflects starting numbers and item-level overrides.
  * Added an example showcasing customized ordered-list numbering.

* **Documentation**
  * Updated List component documentation to describe supported native attributes and browser behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->