### PR TITLE
feat(text-group): review a11y issues, align examples with figma #842

### DIFF
--- a/src/tedi/components/content/text-group/text-group-list/text-group-list.tsx
+++ b/src/tedi/components/content/text-group/text-group-list/text-group-list.tsx
@@ -15,13 +15,13 @@ type TextGroupListBreakpointProps =
       type?: 'horizontal';
       /**
        * Alignment for the label text.
-       * @default 'left'
+       * @default left
        */
       labelAlign?: TextAlign;
       /**
        * Width for the label column (e.g., `'200px'`, `'30%'`, or a `number`
        * interpreted as a percent).
-       * @default 'auto'
+       * @default auto
        */
       labelWidth?: string | number;
     }
@@ -33,13 +33,13 @@ type TextGroupListBreakpointProps =
       /**
        * Alignment for the label text. Vertical layout only supports left
        * alignment — pass `'right'` only with `type: 'horizontal'`.
-       * @default 'left'
+       * @default left
        */
       labelAlign?: 'left';
       /**
        * Width for the label column (e.g., `'200px'`, `'30%'`, or a `number`
        * interpreted as a percent).
-       * @default 'auto'
+       * @default auto
        */
       labelWidth?: string | number;
     };
@@ -51,7 +51,8 @@ export interface TextGroupListItem {
    */
   label: React.ReactNode;
   /**
-   * Value rendered as the `<dd>` for this row.
+   * Value rendered as the `<dd>` for this row. Accepts multiple nodes — a trailing
+   * `StatusBadge`, `Tag`, or info tooltip renders inline beside the text.
    */
   value: React.ReactNode | React.ReactNode[];
   /**

--- a/src/tedi/components/content/text-group/text-group.spec.tsx
+++ b/src/tedi/components/content/text-group/text-group.spec.tsx
@@ -144,6 +144,17 @@ describe('TextGroup component', () => {
     expect(dt?.querySelector('em')).toBeInTheDocument();
     expect(dt?.querySelector('.tedi-label')).not.toBeInTheDocument();
   });
+
+  it('renders multiple value nodes (e.g. text + a trailing badge) inline in the <dd>', () => {
+    const { container } = render(
+      <TextGroup label="Name" value={[<span key="v">Mari Maasikas</span>, <span key="s">Access granted</span>]} />
+    );
+
+    const dd = container.querySelector('dd.tedi-text-group__value');
+    expect(dd).toHaveTextContent('Mari Maasikas');
+    expect(within(dd as HTMLElement).getByText('Access granted')).toBeInTheDocument();
+    expect(dd?.textContent).toBe('Mari MaasikasAccess granted');
+  });
 });
 
 describe('TextGroup.List', () => {

--- a/src/tedi/components/content/text-group/text-group.stories.tsx
+++ b/src/tedi/components/content/text-group/text-group.stories.tsx
@@ -244,6 +244,12 @@ export const TextWeight: Story = {
  */
 export const Types: Story = {
   name: 'Type',
+  parameters: {
+    // The `Has icon` examples use the design's muted `color="tertiary"` decorative icons, which don't
+    // meet text-contrast in isolation. Suppress only the color-contrast rule here (other a11y checks
+    // still run) rather than deviating from Figma.
+    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
+  },
   render: () => (
     <ExampleRows
       rows={[
@@ -279,14 +285,21 @@ export const Types: Story = {
             <VerticalSpacing size={1}>
               <TextGroup
                 label="Ligipääsetavus"
-                value={[
-                  <Icon key="i" name="lock" size={16} color="tertiary" />,
-                  <Text key="v">Nähtav arstile ja esindajale</Text>,
-                ]}
+                value={
+                  <>
+                    <Icon name="lock" size={16} color="tertiary" />
+                    <Text>Nähtav arstile ja esindajale</Text>
+                  </>
+                }
               />
               <TextGroup
                 label="Patsient"
-                value={[<Icon key="i" name="person" size={18} color="tertiary" />, <Text key="v">Mari Maasikas</Text>]}
+                value={
+                  <>
+                    <Icon name="person" size={18} color="tertiary" />
+                    <Text>Mari Maasikas</Text>
+                  </>
+                }
               />
             </VerticalSpacing>
           ),

--- a/src/tedi/components/content/text-group/text-group.stories.tsx
+++ b/src/tedi/components/content/text-group/text-group.stories.tsx
@@ -440,9 +440,12 @@ export const CustomLabel: Story = {
               type="horizontal"
               labelWidth="150px"
               label={
-                <Text modifiers="bold" color="secondary">
-                  Olek <StatusBadge color="success">Aktiivne</StatusBadge>
-                </Text>
+                <div className="flex align-items-center gap-2">
+                  <Text element="span" modifiers="bold" color="secondary">
+                    Olek
+                  </Text>
+                  <StatusBadge color="success">Aktiivne</StatusBadge>
+                </div>
               }
               value={<Text>Olekuga seotud tekst</Text>}
             />

--- a/src/tedi/components/content/text-group/text-group.stories.tsx
+++ b/src/tedi/components/content/text-group/text-group.stories.tsx
@@ -398,27 +398,45 @@ export const Responsive: Story = {
   },
 };
 
+/**
+ * The `label` accepts any node, not just a string — e.g. a bold / secondary label with an info button,
+ * or a status badge inline with the label text.
+ */
 export const CustomLabel: Story = {
+  name: 'Custom label',
   render: () => (
-    <VerticalSpacing>
-      <TextGroup
-        label={
-          <Text modifiers="bold" color="secondary">
-            Authorisations <InfoButton>More information</InfoButton>
-          </Text>
-        }
-        value={<Text>Visible to doctor and representative</Text>}
-      />
-      <TextGroup
-        label={
-          <Text modifiers="bold" color="secondary">
-            Status <StatusBadge color="success">Active</StatusBadge>
-          </Text>
-        }
-        value={<Text>Some text regarding to status</Text>}
-        type="horizontal"
-      />
-    </VerticalSpacing>
+    <ExampleRows
+      rows={[
+        {
+          title: 'With info button',
+          content: (
+            <TextGroup
+              label={
+                <Text modifiers="bold" color="secondary">
+                  Volitused <InfoButton aria-label="Rohkem infot" />
+                </Text>
+              }
+              value={<Text>Arstile ja esindajale nähtav</Text>}
+            />
+          ),
+        },
+        {
+          title: 'With status badge',
+          content: (
+            <TextGroup
+              type="horizontal"
+              labelWidth="150px"
+              label={
+                <Text modifiers="bold" color="secondary">
+                  Olek <StatusBadge color="success">Aktiivne</StatusBadge>
+                </Text>
+              }
+              value={<Text>Olekuga seotud tekst</Text>}
+            />
+          ),
+        },
+      ]}
+    />
   ),
 };
 
@@ -439,10 +457,10 @@ export const WithList: Story = {
           content: (
             <TextGroup.List
               items={[
-                { label: 'Patient', value: <Text>Mari Maasikas</Text> },
-                { label: 'Address', value: <Text>Tulbi tn 4, Tallinn, 23562, Estonia</Text> },
-                { label: 'Vaccine', value: <Text>COVID-19 mRNA</Text> },
-                { label: 'Next vaccination', value: <Text>Immunization finished</Text> },
+                { label: 'Patsient', value: <Text>Mari Maasikas</Text> },
+                { label: 'Aadress', value: <Text>Tulbi tn 4, Tallinn, 23562, Eesti</Text> },
+                { label: 'Vaktsiin', value: <Text>COVID-19 mRNA</Text> },
+                { label: 'Järgmine vaktsineerimine', value: <Text>Immuniseerimine lõpetatud</Text> },
               ]}
             />
           ),
@@ -455,7 +473,7 @@ export const WithList: Story = {
               labelWidth="220px"
               items={[
                 {
-                  label: 'Patient',
+                  label: 'Patsient',
                   value: (
                     <>
                       <Icon name="person" size={18} color="tertiary" />
@@ -464,17 +482,17 @@ export const WithList: Story = {
                   ),
                 },
                 {
-                  label: 'Address',
+                  label: 'Aadress',
                   value: (
                     <>
                       <Icon name="location_on" size={16} color="tertiary" />
-                      <Text>Tulbi tn 4, Tallinn, 23562, Estonia</Text>
+                      <Text>Tulbi tn 4, Tallinn, 23562, Eesti</Text>
                     </>
                   ),
                 },
-                { label: 'Healthcare provider', value: <Text>SA Põhja-Eesti Regionaalhaigla</Text> },
-                { label: 'Healthcare specialist', value: <Text>Mart Mets</Text> },
-                { label: 'Document creation time', value: <Text>16.08.2023 14:51:48</Text> },
+                { label: 'Tervishoiuteenuse osutaja', value: <Text>SA Põhja-Eesti Regionaalhaigla</Text> },
+                { label: 'Tervishoiutöötaja', value: <Text>Mart Mets</Text> },
+                { label: 'Dokumendi loomise aeg', value: <Text>16.08.2023 14:51:48</Text> },
               ]}
             />
           ),
@@ -486,12 +504,12 @@ export const WithList: Story = {
               type="horizontal"
               labelWidth="160px"
               items={[
-                { label: 'Item', value: <Text>USB-C charging cable</Text> },
-                { label: 'Quantity', value: <Text>2</Text> },
-                { label: 'Unit price', value: <Text>€ 12.50</Text>, labelAlign: 'right', labelWidth: '220px' },
+                { label: 'Toode', value: <Text>USB-C laadimiskaabel</Text> },
+                { label: 'Kogus', value: <Text>2</Text> },
+                { label: 'Ühiku hind', value: <Text>12.50 €</Text>, labelAlign: 'right', labelWidth: '220px' },
                 {
-                  label: 'Total',
-                  value: <Text modifiers="bold">€ 25.00</Text>,
+                  label: 'Kokku',
+                  value: <Text modifiers="bold">25.00 €</Text>,
                   labelAlign: 'right',
                   labelWidth: '220px',
                 },

--- a/src/tedi/components/content/text-group/text-group.stories.tsx
+++ b/src/tedi/components/content/text-group/text-group.stories.tsx
@@ -70,7 +70,7 @@ const MultipleTextGroupsTemplate: StoryFn<TextGroupProps> = (args) => {
           label: 'Patsient',
           value: (
             <>
-              <Icon name="person" size={18} color="tertiary" />
+              <Icon name="person" size={18} color="secondary" />
               <Text>Mari Maasikas</Text>
             </>
           ),
@@ -79,7 +79,7 @@ const MultipleTextGroupsTemplate: StoryFn<TextGroupProps> = (args) => {
           label: 'Aadress',
           value: (
             <>
-              <Icon name="location_on" size={16} color="tertiary" />
+              <Icon name="location_on" size={16} color="secondary" />
               <Text>Tulbi tn 4, Tallinn, 23562, Eesti</Text>
             </>
           ),
@@ -244,12 +244,6 @@ export const TextWeight: Story = {
  */
 export const Types: Story = {
   name: 'Type',
-  parameters: {
-    // The `Has icon` examples use the design's muted `color="tertiary"` decorative icons, which don't
-    // meet text-contrast in isolation. Suppress only the color-contrast rule here (other a11y checks
-    // still run) rather than deviating from Figma.
-    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
-  },
   render: () => (
     <ExampleRows
       rows={[
@@ -287,7 +281,7 @@ export const Types: Story = {
                 label="Ligipääsetavus"
                 value={
                   <>
-                    <Icon name="lock" size={16} color="tertiary" />
+                    <Icon name="lock" size={16} color="secondary" />
                     <Text>Nähtav arstile ja esindajale</Text>
                   </>
                 }
@@ -296,7 +290,7 @@ export const Types: Story = {
                 label="Patsient"
                 value={
                   <>
-                    <Icon name="person" size={18} color="tertiary" />
+                    <Icon name="person" size={18} color="secondary" />
                     <Text>Mari Maasikas</Text>
                   </>
                 }
@@ -492,7 +486,7 @@ export const WithList: Story = {
                   label: 'Patsient',
                   value: (
                     <>
-                      <Icon name="person" size={18} color="tertiary" />
+                      <Icon name="person" size={18} color="secondary" />
                       <Text>Mari Maasikas</Text>
                     </>
                   ),
@@ -501,7 +495,7 @@ export const WithList: Story = {
                   label: 'Aadress',
                   value: (
                     <>
-                      <Icon name="location_on" size={16} color="tertiary" />
+                      <Icon name="location_on" size={16} color="secondary" />
                       <Text>Tulbi tn 4, Tallinn, 23562, Eesti</Text>
                     </>
                   ),

--- a/src/tedi/components/content/text-group/text-group.stories.tsx
+++ b/src/tedi/components/content/text-group/text-group.stories.tsx
@@ -1,11 +1,14 @@
 import { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { ReactNode } from 'react';
 
 import { Icon } from '../../base/icon/icon';
 import { Text } from '../../base/typography/text/text';
 import InfoButton from '../../buttons/info-button/info-button';
 import { Col, Row } from '../../layout/grid';
 import { VerticalSpacing } from '../../layout/vertical-spacing';
+import { Link } from '../../navigation/link/link';
 import { StatusBadge } from '../../tags/status-badge/status-badge';
+import { Label } from '../label/label';
 import { TextGroup, TextGroupProps } from './text-group';
 
 /**
@@ -64,7 +67,7 @@ const MultipleTextGroupsTemplate: StoryFn<TextGroupProps> = (args) => {
       labelWidth: '150px',
       items: [
         {
-          label: 'Patient',
+          label: 'Patsient',
           value: (
             <>
               <Icon name="person" size={18} color="tertiary" />
@@ -73,11 +76,11 @@ const MultipleTextGroupsTemplate: StoryFn<TextGroupProps> = (args) => {
           ),
         },
         {
-          label: 'Address',
+          label: 'Aadress',
           value: (
             <>
               <Icon name="location_on" size={16} color="tertiary" />
-              <Text>Tulbi tn 4, Tallinn, 23562, Estonia</Text>
+              <Text>Tulbi tn 4, Tallinn, 23562, Eesti</Text>
             </>
           ),
         },
@@ -87,12 +90,12 @@ const MultipleTextGroupsTemplate: StoryFn<TextGroupProps> = (args) => {
       labelWidth: '180px',
       items: [
         {
-          label: 'Vaccine',
+          label: 'Vaktsiin',
           value: <Text>Mari Maasikas</Text>,
         },
         {
-          label: 'Next vaccination',
-          value: <Text>Immunization finished</Text>,
+          label: 'Järgmine vaktsineerimine',
+          value: <Text>Vaktsineerimine lõpetatud</Text>,
         },
       ],
     },
@@ -100,15 +103,15 @@ const MultipleTextGroupsTemplate: StoryFn<TextGroupProps> = (args) => {
       labelWidth: '200px',
       items: [
         {
-          label: 'Healthcare provider',
+          label: 'Tervishoiuteenuse osutaja',
           value: <Text>SA Põhja-Eesti Regionaalhaigla</Text>,
         },
         {
-          label: 'Healthcare specialist',
+          label: 'Tervishoiutöötaja',
           value: <Text>Mart Mets</Text>,
         },
         {
-          label: 'Document creation time',
+          label: 'Dokumendi loomise aeg',
           value: <Text>16.08.2023 14:51:48</Text>,
         },
       ],
@@ -130,73 +133,211 @@ const MultipleTextGroupsTemplate: StoryFn<TextGroupProps> = (args) => {
   );
 };
 
-const TemplateWithTypes: StoryFn<TextGroupProps> = (args) => {
-  return (
-    <Row>
-      <Col>
-        <VerticalSpacing size={1}>
-          <TextGroup {...args} type="vertical" labelAlign="left" />
-          <TextGroup
-            {...args}
-            type="vertical"
-            labelAlign="left"
-            value={
-              <>
-                <Icon name="lock" size={16} color="tertiary" />
-                <Text>Visible to doctor and representative</Text>
-              </>
-            }
-          />
-          <TextGroup
-            {...args}
-            type="vertical"
-            labelAlign="left"
-            value={<Text modifiers="bold">Visible to doctor and representative</Text>}
-          />
-          <TextGroup
-            label="Patient"
-            value={
-              <>
-                <Icon name="person" size={18} color="tertiary" />
-                <Text>Mari Maasikas</Text>
-              </>
-            }
-            type="horizontal"
-          />
-        </VerticalSpacing>
-      </Col>
-    </Row>
-  );
+/**
+ * Renders titled examples as a two-column list — the variant name on the left, the example(s) on the
+ * right — with a divider between rows, so each variant is clearly separated.
+ */
+const ExampleRows = ({ rows }: { rows: { title: string; content: ReactNode }[] }): JSX.Element => (
+  <Row>
+    <Col className="example-list">
+      {rows.map((row, key) => (
+        <Row className={`${key === rows.length - 1 ? '' : 'border-bottom'} padding-14-16`} key={key}>
+          <Col width={12} md={3} className="flex align-items-center">
+            <Text modifiers="bold">{row.title}</Text>
+          </Col>
+          <Col width={12} md={9}>
+            {row.content}
+          </Col>
+        </Row>
+      ))}
+    </Col>
+  </Row>
+);
+
+export const Default: Story = {
+  args: {
+    label: 'Ligipääsetavus',
+    value: <Text>Arstile ja esindajale nähtav</Text>,
+  },
 };
 
 /**
- * The default story is an interactive playground for a single `TextGroup` — its own props
- * (`label`, `value`, `type`, `labelAlign`, `labelWidth`) are the live controls. The
- * compound `TextGroup.List` is documented in the **With list** story and its autodocs prop
- * table; it isn't given separate live controls because it shares every prop with
- * `TextGroup`, so they would only duplicate these.
+ * Position of the value relative to the label: stacked (`vertical`) or side by side
+ * (`horizontal`) with the label aligned left or right.
  */
-export const Default: Story = {
-  args: {
-    label: 'Accessibility',
-    value: <Text>Visible to doctor and representative</Text>,
-  },
-};
-
-export const Types: Story = {
-  render: TemplateWithTypes,
-  args: {
-    label: 'Accessibility',
-    value: <Text>Visible to doctor and representative</Text>,
-  },
-};
-
 export const PositionType: Story = {
-  render: TemplateWithLayouts,
-  args: {
-    label: 'Accessibility',
-    value: <Text>Visible to doctor and representative</Text>,
-  },
+  name: 'Position',
+  render: () => (
+    <ExampleRows
+      rows={[
+        {
+          title: 'Vertical',
+          content: (
+            <TextGroup type="vertical" label="Ligipääsetavus" value={<Text>Arstile ja esindajale nähtav</Text>} />
+          ),
+        },
+        {
+          title: 'Horizontal, label left',
+          content: (
+            <TextGroup
+              type="horizontal"
+              labelWidth="150px"
+              label="Ligipääsetavus"
+              value={<Text>Arstile ja esindajale nähtav</Text>}
+            />
+          ),
+        },
+        {
+          title: 'Horizontal, label right',
+          content: (
+            <TextGroup
+              type="horizontal"
+              labelWidth="150px"
+              labelAlign="right"
+              label="Ligipääsetavus"
+              value={<Text>Arstile ja esindajale nähtav</Text>}
+            />
+          ),
+        },
+      ]}
+    />
+  ),
+};
+
+/**
+ * Both the label and the value can be regular or bold. Keep the weight consistent throughout the
+ * project — pick one convention and stick to it.
+ */
+export const TextWeight: Story = {
+  name: 'Text weight',
+  render: () => (
+    <ExampleRows
+      rows={[
+        {
+          title: 'Regular label',
+          content: <TextGroup label="Ligipääsetavus" value={<Text>Arstile ja esindajale nähtav</Text>} />,
+        },
+        {
+          title: 'Bold label',
+          content: (
+            <TextGroup label={<Label isBold>Ligipääsetavus</Label>} value={<Text>Nähtav arstile ja esindajale</Text>} />
+          ),
+        },
+        {
+          title: 'Regular value',
+          content: <TextGroup label="Ligipääsetavus" value={<Text>Nähtav arstile ja esindajale</Text>} />,
+        },
+        {
+          title: 'Bold value',
+          content: (
+            <TextGroup label="Ligipääsetavus" value={<Text modifiers="bold">Nähtav arstile ja esindajale</Text>} />
+          ),
+        },
+      ]}
+    />
+  ),
+};
+
+/**
+ * The value can carry extra content beside the text: a link, a leading icon, or a status badge.
+ * (For a trailing element like an info tooltip or a tag, see the **Has slot** story.)
+ */
+export const Types: Story = {
+  name: 'Type',
+  render: () => (
+    <ExampleRows
+      rows={[
+        {
+          title: 'Has link',
+          content: (
+            <VerticalSpacing size={1}>
+              <TextGroup label="Ligipääsetavus" value={<Text>Nähtav arstile ja esindajale</Text>} />
+              <TextGroup
+                label="Ligipääsetavus"
+                value={[
+                  <Text key="v">Nähtav arstile ja esindajale</Text>,
+                  <Link key="l" href="#">
+                    Vaata dokumenti
+                  </Link>,
+                ]}
+              />
+              <TextGroup
+                label="Ligipääsetavus"
+                value={[
+                  <Text key="v">Nähtav arstile ja esindajale</Text>,
+                  <Link key="l" href="#">
+                    dokument nr 4534
+                  </Link>,
+                ]}
+              />
+            </VerticalSpacing>
+          ),
+        },
+        {
+          title: 'Has icon',
+          content: (
+            <VerticalSpacing size={1}>
+              <TextGroup
+                label="Ligipääsetavus"
+                value={[
+                  <Icon key="i" name="lock" size={16} color="tertiary" />,
+                  <Text key="v">Nähtav arstile ja esindajale</Text>,
+                ]}
+              />
+              <TextGroup
+                label="Patsient"
+                value={[<Icon key="i" name="person" size={18} color="tertiary" />, <Text key="v">Mari Maasikas</Text>]}
+              />
+            </VerticalSpacing>
+          ),
+        },
+        {
+          title: 'Has status',
+          content: (
+            <TextGroup
+              label="Ligipääs"
+              value={
+                <VerticalSpacing size={0.25}>
+                  <Text>Arstile ja esindajale nähtav</Text>
+                  <StatusBadge color="brand">Esitatud</StatusBadge>
+                </VerticalSpacing>
+              }
+            />
+          ),
+        },
+      ]}
+    />
+  ),
+};
+
+/**
+ * The Figma "Has slot" variant is just a `value` that carries a trailing element — an info tooltip, a
+ * `StatusBadge`, a `Tag`, etc. Because `value` accepts multiple nodes and the value row is a flex
+ * container with a small gap, the extra element sits inline beside the text (which hugs its content).
+ * No dedicated slot prop is needed — pass an array or a fragment as the `value`.
+ */
+export const HasSlot: Story = {
+  name: 'Has slot',
+  render: () => (
+    <VerticalSpacing size={1}>
+      <TextGroup
+        label="Ligipääs"
+        value={[
+          <Text key="v">Arstile ja esindajale nähtav</Text>,
+          <InfoButton key="s" aria-label="Lisainfo ligipääsu kohta" />,
+        ]}
+      />
+      <TextGroup
+        label="Nimi"
+        value={[
+          <Text key="v">Mari Maasikas</Text>,
+          <StatusBadge key="s" color="success">
+            Ligipääs lubatud
+          </StatusBadge>,
+        ]}
+      />
+    </VerticalSpacing>
+  ),
 };
 
 export const HorizontalLabelLength: Story = {
@@ -222,15 +363,39 @@ export const LongTextValues: Story = {
   },
 };
 
-export const ResponsiveLayoutChange: Story = {
-  args: {
-    label: 'Accessibility',
-    value: <Text>Visible to doctor and representative</Text>,
-    md: { type: 'vertical' },
-    lg: { type: 'horizontal' },
-  },
+/**
+ * Override the label `type` and `labelWidth` per breakpoint. Below `sm` the label stacks above the
+ * value; from `sm` up it sits beside the value, widening at `md` and `lg`. Resize the preview to see
+ * the layout adapt.
+ */
+export const Responsive: Story = {
+  render: () => {
+    const rows = [
+      { label: 'Patsient', value: 'Mari Maasikas' },
+      { label: 'Aadress', value: 'Tulbi tn 4, Tallinn, 23562, Eesti' },
+      { label: 'Vaktsiin', value: 'Mari Maasikas' },
+      { label: 'Järgmine vaktsineerimine', value: 'Immuniseerimine lõpetatud' },
+      { label: 'Tervishoiuteenuse osutaja', value: 'SA Põhja-Eesti Regionaalhaigla' },
+      { label: 'Tervishoiutöötaja', value: 'Mart Mets' },
+      { label: 'Dokumendi loomise aeg', value: '16.08.2023 14:51:48' },
+    ];
 
-  render: (args) => <TextGroup {...args} />,
+    return (
+      <VerticalSpacing size={0.25}>
+        {rows.map((row, index) => (
+          <TextGroup
+            key={index}
+            type="vertical"
+            sm={{ type: 'horizontal', labelWidth: '120px' }}
+            md={{ labelWidth: '200px' }}
+            lg={{ labelWidth: '25%' }}
+            label={row.label}
+            value={<Text>{row.value}</Text>}
+          />
+        ))}
+      </VerticalSpacing>
+    );
+  },
 };
 
 export const CustomLabel: Story = {
@@ -267,57 +432,74 @@ export const CustomLabel: Story = {
  */
 export const WithList: Story = {
   render: () => (
-    <VerticalSpacing size={1.5}>
-      <Text modifiers="bold">Vertical list (default)</Text>
-      <TextGroup.List
-        items={[
-          { label: 'Patient', value: <Text>Mari Maasikas</Text> },
-          { label: 'Address', value: <Text>Tulbi tn 4, Tallinn, 23562, Estonia</Text> },
-          { label: 'Vaccine', value: <Text>COVID-19 mRNA</Text> },
-          { label: 'Next vaccination', value: <Text>Immunization finished</Text> },
-        ]}
-      />
-
-      <Text modifiers="bold">Horizontal list with shared label column</Text>
-      <TextGroup.List
-        type="horizontal"
-        labelWidth="220px"
-        items={[
-          {
-            label: 'Patient',
-            value: (
-              <>
-                <Icon name="person" size={18} color="tertiary" />
-                <Text>Mari Maasikas</Text>
-              </>
-            ),
-          },
-          {
-            label: 'Address',
-            value: (
-              <>
-                <Icon name="location_on" size={16} color="tertiary" />
-                <Text>Tulbi tn 4, Tallinn, 23562, Estonia</Text>
-              </>
-            ),
-          },
-          { label: 'Healthcare provider', value: <Text>SA Põhja-Eesti Regionaalhaigla</Text> },
-          { label: 'Healthcare specialist', value: <Text>Mart Mets</Text> },
-          { label: 'Document creation time', value: <Text>16.08.2023 14:51:48</Text> },
-        ]}
-      />
-
-      <Text modifiers="bold">Per-row labelAlign / labelWidth overrides</Text>
-      <TextGroup.List
-        type="horizontal"
-        labelWidth="160px"
-        items={[
-          { label: 'Item', value: <Text>USB-C charging cable</Text> },
-          { label: 'Quantity', value: <Text>2</Text> },
-          { label: 'Unit price', value: <Text>€ 12.50</Text>, labelAlign: 'right', labelWidth: '220px' },
-          { label: 'Total', value: <Text modifiers="bold">€ 25.00</Text>, labelAlign: 'right', labelWidth: '220px' },
-        ]}
-      />
-    </VerticalSpacing>
+    <ExampleRows
+      rows={[
+        {
+          title: 'Vertical list (default)',
+          content: (
+            <TextGroup.List
+              items={[
+                { label: 'Patient', value: <Text>Mari Maasikas</Text> },
+                { label: 'Address', value: <Text>Tulbi tn 4, Tallinn, 23562, Estonia</Text> },
+                { label: 'Vaccine', value: <Text>COVID-19 mRNA</Text> },
+                { label: 'Next vaccination', value: <Text>Immunization finished</Text> },
+              ]}
+            />
+          ),
+        },
+        {
+          title: 'Horizontal list with shared label column',
+          content: (
+            <TextGroup.List
+              type="horizontal"
+              labelWidth="220px"
+              items={[
+                {
+                  label: 'Patient',
+                  value: (
+                    <>
+                      <Icon name="person" size={18} color="tertiary" />
+                      <Text>Mari Maasikas</Text>
+                    </>
+                  ),
+                },
+                {
+                  label: 'Address',
+                  value: (
+                    <>
+                      <Icon name="location_on" size={16} color="tertiary" />
+                      <Text>Tulbi tn 4, Tallinn, 23562, Estonia</Text>
+                    </>
+                  ),
+                },
+                { label: 'Healthcare provider', value: <Text>SA Põhja-Eesti Regionaalhaigla</Text> },
+                { label: 'Healthcare specialist', value: <Text>Mart Mets</Text> },
+                { label: 'Document creation time', value: <Text>16.08.2023 14:51:48</Text> },
+              ]}
+            />
+          ),
+        },
+        {
+          title: 'Per-row labelAlign / labelWidth overrides',
+          content: (
+            <TextGroup.List
+              type="horizontal"
+              labelWidth="160px"
+              items={[
+                { label: 'Item', value: <Text>USB-C charging cable</Text> },
+                { label: 'Quantity', value: <Text>2</Text> },
+                { label: 'Unit price', value: <Text>€ 12.50</Text>, labelAlign: 'right', labelWidth: '220px' },
+                {
+                  label: 'Total',
+                  value: <Text modifiers="bold">€ 25.00</Text>,
+                  labelAlign: 'right',
+                  labelWidth: '220px',
+                },
+              ]}
+            />
+          ),
+        },
+      ]}
+    />
   ),
 };

--- a/src/tedi/components/content/text-group/text-group.tsx
+++ b/src/tedi/components/content/text-group/text-group.tsx
@@ -16,12 +16,12 @@ type TextGroupBreakpointProps =
       type?: 'horizontal';
       /**
        * Alignment for the label text
-       *  @default 'left'
+       *  @default left
        */
       labelAlign?: TextAlign;
       /**
        * Width for the label (e.g., '200px', '30%', etc.)
-       * @default 'auto'
+       * @default auto
        */
       labelWidth?: string | number;
     }
@@ -32,12 +32,12 @@ type TextGroupBreakpointProps =
       type: 'vertical';
       /**
        * Alignment for the label text
-       *  @default 'left'
+       *  @default left
        */
       labelAlign?: 'left';
       /**
        * Width for the label (e.g., '200px', '30%', etc.)
-       * @default 'auto'
+       * @default auto
        */
       labelWidth?: string | number;
     };
@@ -48,7 +48,9 @@ export type TextGroupProps = BreakpointSupport<TextGroupBreakpointProps> & {
    */
   label: React.ReactNode;
   /**
-   * Value displayed alongside the label
+   * Value displayed alongside the label. Accepts multiple nodes — a trailing
+   * `StatusBadge`, `Tag`, or info tooltip renders inline beside the text (the
+   * value row is a flex container with a small gap).
    */
   value: React.ReactNode | React.ReactNode[];
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `TextGroup` label alignment and width defaults.
  * Expanded guidance for displaying multiple inline values and trailing elements.

* **Examples**
  * Updated `TextGroup` examples with localized content.
  * Added responsive layout and trailing-content examples.
  * Improved examples for custom labels, types, positioning, and lists.

* **Tests**
  * Added coverage confirming multiple value nodes render inline while preserving combined text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->